### PR TITLE
Update README to use pnpm as the package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OpenAuditLabs/Site serves as the digital front door for the OpenAuditLabs projec
 ### Prerequisites
 
 - Node.js 18.0 or later
-- npm package manager
+- pnpm package manager
 
 ### Installation
 
@@ -47,14 +47,14 @@ OpenAuditLabs/Site serves as the digital front door for the OpenAuditLabs projec
 2. **Install dependencies**
 
    ```bash
-   npm install
+   pnpm install
    ```
 
 
 3. **Run the development server**
 
    ```bash
-   npm run dev
+   pnpm dev
    ```
 
 4. **Open your browser**
@@ -65,8 +65,8 @@ OpenAuditLabs/Site serves as the digital front door for the OpenAuditLabs projec
 ### Building for Production
 
 ```bash
-npm run build
-npm start
+pnpm run build
+pnpm start
 ```
 
 ## Development


### PR DESCRIPTION
## Description

This PR updates the README to reflect the project’s migration from npm to pnpm as the package manager. All setup, installation, and script commands in the documentation now use `pnpm`. Any remaining references to npm or `package-lock.json` have been removed or revised for clarity.

## Related Issue

Closes #11 

## Type of Change

- [x] Documentation update

## Checklist

- [x] All npm commands replaced with pnpm equivalents in README
- [x] Removal of any npm-specific references (e.g., `package-lock.json`)
- [x] Instructions are clear for users working with pnpm

## Notes

All contributors and users should now refer to pnpm-based instructions for project setup and development.