### PR TITLE
feat: add social media links with icons to contact section

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import { ContactForm } from "@/components/ContactForm";
+import { SocialMediaLinks } from "@/components/ui";
 
 export default function Contact() {
   return (
@@ -17,6 +18,19 @@ export default function Contact() {
 
         {/* Contact Form */}
         <ContactForm />
+
+        {/* Social Media Links Section */}
+        <div className="mt-16 text-center">
+          <h2 className="text-2xl font-semibold text-foreground mb-4">
+            Connect With Us
+          </h2>
+          <p className="text-muted-foreground mb-8 max-w-lg mx-auto">
+            Follow us on social media for the latest updates on smart contract
+            security, industry insights, and company news.
+          </p>
+
+          <SocialMediaLinks className="justify-center" />
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -22,3 +22,4 @@ export {
 } from "./dialog";
 export { Breadcrumb } from "./breadcrumb";
 export { Table, type TableProps, type Column } from "./table";
+export { SocialMediaLinks } from "./social-media-links";

--- a/src/components/ui/social-media-links.tsx
+++ b/src/components/ui/social-media-links.tsx
@@ -1,0 +1,100 @@
+import { Github, Twitter, Linkedin } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface SocialMediaLink {
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  platform: string;
+}
+
+interface SocialMediaLinksProps {
+  className?: string;
+  iconSize?: "sm" | "md" | "lg";
+  variant?: "default" | "minimal" | "filled";
+  showLabels?: boolean;
+}
+
+const socialMediaLinks: SocialMediaLink[] = [
+  {
+    href: "https://github.com/OpenAuditLabs",
+    icon: Github,
+    label: "OpenAudit Labs on GitHub",
+    platform: "GitHub",
+  },
+  {
+    href: "https://twitter.com/OpenAuditLabs",
+    icon: Twitter,
+    label: "OpenAudit Labs on Twitter",
+    platform: "Twitter",
+  },
+  {
+    href: "https://linkedin.com/company/openauditlabs",
+    icon: Linkedin,
+    label: "OpenAudit Labs on LinkedIn",
+    platform: "LinkedIn",
+  },
+];
+
+const iconSizeClasses = {
+  sm: "w-4 h-4",
+  md: "w-5 h-5",
+  lg: "w-6 h-6",
+};
+
+const containerSizeClasses = {
+  sm: "w-9 h-9",
+  md: "w-12 h-12",
+  lg: "w-14 h-14",
+};
+
+export function SocialMediaLinks({
+  className,
+  iconSize = "md",
+  variant = "default",
+  showLabels = false,
+}: SocialMediaLinksProps) {
+  const getVariantClasses = () => {
+    switch (variant) {
+      case "minimal":
+        return "text-muted-foreground hover:text-foreground transition-colors duration-200";
+      case "filled":
+        return "bg-primary text-primary-foreground hover:bg-primary/90 transition-all duration-200 hover:shadow-lg hover:scale-110";
+      default:
+        return "bg-background border border-border hover:border-primary transition-all duration-200 hover:bg-primary hover:text-primary-foreground hover:shadow-lg hover:scale-110";
+    }
+  };
+
+  return (
+    <ul className={cn("flex items-center gap-4", className)}>
+      {socialMediaLinks.map((link) => {
+        const Icon = link.icon;
+
+        return (
+          <li key={link.platform}>
+            <a
+              href={link.href}
+              aria-label={link.label}
+              className={cn(
+                "group flex items-center justify-center rounded-full transition-all duration-200",
+                containerSizeClasses[iconSize],
+                getVariantClasses(),
+                showLabels && "flex-row gap-2 px-4 w-auto h-10"
+              )}
+            >
+              <Icon
+                className={cn(
+                  iconSizeClasses[iconSize],
+                  "transition-transform duration-200 group-hover:scale-110"
+                )}
+              />
+              {showLabels && (
+                <span className="text-sm font-medium">{link.platform}</span>
+              )}
+            </a>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}


### PR DESCRIPTION
## PR Description

### 📋 Overview
This PR implements adding social media links with icons to the contact section. Users can now easily connect with OpenAudit Labs through GitHub, Twitter, and LinkedIn directly from the contact page.

### ✨ What's New
- **New Social Media Section**: Added a dedicated "Connect With Us" section below the contact form
- **Reusable Component**: Created a flexible `SocialMediaLinks` component with multiple styling variants
- **Professional Icons**: Integrated GitHub, Twitter, and LinkedIn icons from `lucide-react`
- **Responsive Design**: Links are properly centered and responsive across all screen sizes

### 🎨 Features Implemented
- ✅ **Social Media Links**: GitHub, Twitter, and LinkedIn links added
- ✅ **Icon Integration**: Used `lucide-react` icons (Github, Twitter, Linkedin)
- ✅ **Consistent Styling**: Follows existing design system patterns
- ✅ **Hover Effects**: Smooth transitions with scale and color changes
- ✅ **Accessibility Ready**: Proper aria-labels included for screen readers
- ✅ **Reusable Component**: Flexible component with multiple variants and sizes



