### PR TITLE
feat: add audit process section with light/dark support

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import {
   JoinMission,
   TrustedLeadingProtocols,
   PricingSection,
+  AuditProcess,
 } from "@/components/sections";
 import ReadyToSecure from "@/components/sections/ReadyToSecure";
 
@@ -13,6 +14,7 @@ export default function Home() {
       <HeroSection />
       <PortfolioStats />
       <PricingSection/>
+      <AuditProcess />
       <ReadyToSecure />
       <TrustedLeadingProtocols />
       <JoinMission />

--- a/src/components/animations/FadeIn.tsx
+++ b/src/components/animations/FadeIn.tsx
@@ -1,1 +1,28 @@
-// fadein animation
+'use client';
+
+import { motion } from 'framer-motion';
+import type { ReactNode } from 'react';
+
+export default function FadeIn({
+  children,
+  delay = 0,
+  distance = 32,
+  className,
+}: {
+  children: ReactNode;
+  delay?: number;
+  distance?: number;
+  className?: string;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: distance }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: '-80px' }}
+      transition={{ duration: 0.6, delay, ease: [0.25, 0.46, 0.45, 0.94] }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/animations/StaggerAnimation.tsx
+++ b/src/components/animations/StaggerAnimation.tsx
@@ -1,1 +1,33 @@
-// stagger animation here
+'use client';
+
+import { motion } from 'framer-motion';
+import type { ReactNode } from 'react';
+
+export default function StaggerAnimation({
+  children,
+  delayChildren = 0.05,
+  staggerChildren = 0.08,
+  className,
+}: {
+  children: ReactNode;
+  delayChildren?: number;
+  staggerChildren?: number;
+  className?: string;
+}) {
+  return (
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: '-80px' }}
+      variants={{
+        hidden: {},
+        visible: {
+          transition: { delayChildren, staggerChildren },
+        },
+      }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/animations/index.ts
+++ b/src/components/animations/index.ts
@@ -1,1 +1,3 @@
 // animations exported from here
+export { default as FadeIn } from './FadeIn';
+export { default as StaggerAnimation } from './StaggerAnimation';

--- a/src/components/sections/AuditProcess.tsx
+++ b/src/components/sections/AuditProcess.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { ClipboardList, Eye, FileCode2, Search } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+const steps = [
+	{
+		id: 1,
+		title: 'Code Analysis',
+		description:
+			'Deep static analysis of your smart contract code to identify potential vulnerabilities',
+		icon: Search,
+	},
+	{
+		id: 2,
+		title: 'Automated Testing',
+		description:
+			'Comprehensive automated testing suite covering edge cases and attack vectors',
+		icon: FileCode2,
+	},
+	{
+		id: 3,
+		title: 'Manual Review',
+		description:
+			'Expert manual review by senior security auditors for logic flaws',
+		icon: Eye,
+	},
+	{
+		id: 4,
+		title: 'Final Report',
+		description:
+			'Detailed report with findings, severity levels, and remediation recommendations',
+		icon: ClipboardList,
+	},
+] as const;
+
+export default function AuditProcess() {
+	return (
+		<section
+			aria-labelledby="audit-process-title"
+			className="relative w-full bg-background py-20 sm:py-24 lg:py-28 overflow-hidden"
+		>
+			{/* subtle atmospheric glows (non-intrusive and accessible in light/dark) */}
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute top-10 left-[10%] h-72 w-72 rounded-full bg-primary/10 blur-3xl" />
+				<div className="absolute bottom-10 right-[12%] h-64 w-64 rounded-full bg-accent/10 blur-3xl" />
+			</div>
+
+			<div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 relative">
+				{/* Heading */}
+				<motion.div
+					initial={{ opacity: 0, y: 24 }}
+					whileInView={{ opacity: 1, y: 0 }}
+					viewport={{ once: true, margin: '-100px' }}
+					transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
+					className="text-center"
+				>
+					<h2
+						id="audit-process-title"
+						className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight mb-6"
+					>
+						<span className="bg-gradient-to-r from-cyan-400 via-blue-500 to-fuchsia-500 bg-clip-text text-transparent">
+							Our Audit Process
+						</span>
+					</h2>
+					<p className="mx-auto max-w-4xl text-base sm:text-lg lg:text-xl leading-relaxed text-muted-foreground">
+						A comprehensive approach to smart contract security combining
+						cutting-edge automation with expert human analysis
+					</p>
+				</motion.div>
+
+				{/* Steps */}
+				<ol
+					role="list"
+					aria-label="Audit steps"
+					className="mt-14 grid grid-cols-1 gap-6 sm:gap-8 md:grid-cols-2 lg:grid-cols-4"
+				>
+					{steps.map((step, idx) => {
+						const Icon = step.icon;
+						const titleId = `step-${step.id}-title`;
+						const descId = `step-${step.id}-desc`;
+						return (
+							<motion.li
+								key={step.id}
+								initial={{ opacity: 0, y: 32 }}
+								whileInView={{ opacity: 1, y: 0 }}
+								viewport={{ once: true, margin: '-80px' }}
+								transition={{
+									duration: 0.55,
+									delay: idx * 0.08,
+									ease: [0.25, 0.46, 0.45, 0.94],
+								}}
+								className="group relative"
+							>
+								<article
+									tabIndex={0}
+									aria-labelledby={titleId}
+									aria-describedby={descId}
+									className="relative h-full rounded-2xl border border-border bg-card/60 backdrop-blur-sm p-8 pt-10 shadow-sm transition-all duration-300 hover:-translate-y-1.5 hover:border-cyan-400/50 hover:shadow-xl hover:shadow-cyan-500/10 focus-visible:-translate-y-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40"
+								>
+									{/* top-centered icon medallion */}
+									<div className="absolute -top-7 left-1/2 -translate-x-1/2">
+										<div className="relative">
+											<div className="h-14 w-14 rounded-full bg-background ring-2 ring-white/80 dark:ring-white/50 shadow-md flex items-center justify-center">
+												<div className="h-12 w-12 rounded-full bg-foreground/90 dark:bg-black/70 text-white flex items-center justify-center">
+													<Icon
+														aria-hidden
+														className="h-6 w-6 text-cyan-300"
+													/>
+												</div>
+											</div>
+										</div>
+									</div>
+
+									{/* numbered badge */}
+									<div className="absolute top-2 right-4 h-8 w-8 rounded-full bg-gradient-to-br from-cyan-500 to-blue-600 text-white text-sm font-bold shadow-lg grid place-items-center">
+										<span className="sr-only">Step</span>
+										{step.id}
+									</div>
+
+									{/* right connector accent */}
+									{idx < steps.length - 1 && (
+										<div className="pointer-events-none absolute right-0 top-1/2 hidden h-px w-10 -translate-y-1/2 bg-gradient-to-r from-border to-transparent lg:block" />
+									)}
+
+									<h3
+										id={titleId}
+										className="mt-4 text-center text-lg sm:text-xl font-semibold text-foreground"
+									>
+										{step.title}
+									</h3>
+									<p
+										id={descId}
+										className="mt-4 text-center text-sm sm:text-base leading-relaxed text-muted-foreground"
+									>
+										{step.description}
+									</p>
+
+									{/* subtle hover glow */}
+									<div
+										aria-hidden
+										className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+										style={{
+											background:
+												'linear-gradient(135deg, rgba(6,182,212,0.06) 0%, rgba(139,92,246,0.04) 100%)',
+										}}
+									/>
+								</article>
+							</motion.li>
+						);
+					})}
+				</ol>
+			</div>
+		</section>
+	);
+}

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -4,3 +4,4 @@ export { PortfolioStats } from "./PortfolioStats";
 export { JoinMission } from "./JoinMission";
 export { default as TrustedLeadingProtocols } from "./TrustedLeadingProtocols";
 export { default as PricingSection } from "./PricingSection";
+export { default as AuditProcess } from './AuditProcess';


### PR DESCRIPTION

- PR description
  Overview
  - implements a pixel-accurate “our audit process” section matching the provided design
  - full light/dark theme using existing css variables
  - integrates into the home page below portfolio stats

  What’s included
  - new section: AuditProcess.tsx
  - animation utils: FadeIn, StaggerAnimation (framer-motion)
  - barrel exports updated and home page integration
  - lucide-react icons for steps
  - responsive grid (1/2/4 columns) and subtle motion

  Accessibility
  - semantic ol/li for ordered steps
  - aria-labelledby/aria-describedby on cards
  - keyboard focus with focus-visible rings
  - sufficient contrast in both themes

  Design fidelity
  - gradient heading (cyan → blue → fuchsia)
  - centered icon medallions with dual ring
  - numbered step badges and connector lines
  - glassy cards with soft hover glow

  QA checklist
  - theme toggle works and maintains contrast
  - layout scales at sm/md/lg breakpoints
  - tab navigation highlights each card
  - no visual regressions on home page
