### PR TITLE
fix: mobile header alignment & footer social icon layout

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -172,8 +172,9 @@ const Footer = () => {
 
         {/* Bottom section */}
         <div className="border-t border-[var(--border)] mt-12 pt-8">
-          <div className="flex w-full items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
+          <div className="flex w-full flex-col md:flex-row items-center md:justify-between gap-4">
+            {/* Icons block: left on md+, top on mobile */}
+            <div className="flex items-center gap-3 order-1 md:order-1">
               {socialLinks.map((link) => (
                 <a
                   key={link.label}
@@ -187,9 +188,10 @@ const Footer = () => {
                 </a>
               ))}
             </div>
-            <div className="text-sm text-[var(--muted-foreground)]">
-              © 2025 OpenAuditLabs. Open-source under permissive licenses where
-              noted.
+
+            {/* Copyright: right on md+, below on mobile */}
+            <div className="text-sm text-[var(--muted-foreground)] order-2 md:order-2 text-center md:text-right">
+              © 2025 OpenAuditLabs. Open-source under permissive licenses where noted.
             </div>
           </div>
         </div>


### PR DESCRIPTION

### PR description
- Summary
  - Improve mobile header UX by placing the menu icon next to the theme toggle and removing the redundant theme toggle inside the slide-in menu. Update footer to remove social icons under the brand and place them in the bottom row with the copyright text justified between.

- Changes
  - Header: place menu icon and theme toggle side-by-side on mobile; remove duplicate theme toggle from the mobile slide-in.
  - Footer: remove social icons from the brand block; move icons to the footer bottom row and layout using justify-between so icons and copyright sit on opposite ends.
  - Minor accessibility: keep aria-labels/aria-expanded on header controls and maintain link semantics.


- Why
  - Cleans up mobile header for quicker access and reduced redundancy. Places footer icons in a predictable location for consistent visual hierarchy.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated footer layout by relocating social icons to the bottom section for a cleaner structure.
  * Improved responsive behavior: on larger screens, social icons align left while copyright appears on the right; on mobile, icons display above the copyright.
  * Ensures clearer separation of content and a more consistent visual presentation across devices.
  * No changes to functionality or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->