### PR TITLE
feat: add ServiceSection component with badge and descriptive content

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -166,6 +166,14 @@
     0 0 0 1px rgba(0, 0, 0, 0.03) inset;
   /* Feature cards section background (light) and hover border color variables */
   --feature-cards-bg: #f7f8fa;
+  /* Service section badge colors */
+  --service-badge-bg: rgba(
+    36,
+    86,
+    244,
+    0.08
+  ); /* subtle blue background by default */
+  --service-badge-text: var(--navbar-btn-bg);
   --feature-card-border-hover: #06b6d4; /* cyan-500 fallback for hover */
   --feature-card-icon-bg: rgba(6, 182, 212, 0.08);
   --sidebar: oklch(0.985 0.002 247.839);
@@ -218,6 +226,9 @@
     0 0 0 1px rgba(255, 255, 255, 0.03) inset;
   /* Dark equivalents for feature cards */
   --feature-cards-bg: oklch(0.13 0.028 261.692); /* reuse dark background */
+  /* Service section badge colors (dark) */
+  --service-badge-bg: rgba(36, 86, 244, 0.08);
+  --service-badge-text: var(--navbar-btn-text);
   --feature-card-border-hover: #0891b2; /* slightly darker cyan for dark mode */
   --feature-card-icon-bg: rgba(8, 145, 178, 0.08);
   --sidebar: oklch(0.21 0.034 264.665);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import {
   HeroSection,
   FeaturePills,
   FeatureCards,
+  ServiceSection,
   WorkingProcess,
   PortfolioStats,
   JoinMission,
@@ -19,6 +20,7 @@ export default function Home() {
       <HeroSection />
       <FeaturePills />
       <FeatureCards />
+      <ServiceSection />
       <PortfolioStats />
       <AuditProcess />
       <PricingSection />

--- a/src/components/sections/ServiceSection.tsx
+++ b/src/components/sections/ServiceSection.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+export function ServiceSection() {
+  return (
+    <section aria-label="Services" className="w-full my-20 py-12 md:py-20">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl">
+          <span
+            className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium mb-4"
+            style={{
+              background: "var(--service-badge-bg)",
+              color: "var(--service-badge-text)",
+              border: "1px solid var(--border)",
+            }}
+          >
+            Services
+          </span>
+
+          <h2
+            className="text-3xl sm:text-4xl font-extrabold mb-4"
+            style={{ color: "var(--foreground)" }}
+          >
+            Auditing tailored to DeFi, NFTs, DAOs, and core infra.
+          </h2>
+
+          <p
+            className="text-base max-w-prose"
+            style={{ color: "var(--muted-foreground)" }}
+          >
+            We meet teams where they are and apply the right mix of automated
+            and manual techniques.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default ServiceSection;

--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -1,1 +1,0 @@
-// services section

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -11,3 +11,4 @@ export { TeamMemberSection } from "./TeamMemberSection";
 export { FeaturePills } from "./FeaturePills";
 export { default as FeatureCards } from "./FeatureCardsSection";
 export { default as WorkingProcess } from "./WorkingProcessSection";
+export { ServiceSection } from "./ServiceSection";


### PR DESCRIPTION


### PR description
## 🎨 Service Section

This PR adds the Service section placeholder to the homepage and wires it into the sections index so it appears after the Feature cards. It introduces service badge colors via CSS variables (no hardcoded colors), and removes the section background so it inherits the page background. This is the first PR in a two-PR plan — it implements badge, title and subtitle only; service cards will follow in a subsequent PR.

---

### 🔄 Changes Implemented

#### Branding & Content
- ✅ Added service badge text: "Services" (keeps copy from design).
- ✅ Added section title: "Auditing tailored to DeFi, NFTs, DAOs, and core infra."
- ✅ Added section subtitle: "We meet teams where they are and apply the right mix of automated and manual techniques."

#### UI/UX & Layout
- ✅ Inserted `ServiceSection` component into the homepage after `FeatureCards` via index.ts and page.tsx.
- ✅ The section uses semantic markup and a compact layout that matches site structure.

#### Icons & Assets
- ✅ No new icons or external assets added in this PR.

#### Theme & Styling
- ✅ Removed inline hardcoded section background (section now inherits page background).
- ✅ Added CSS variables for service badge colors to `:root` and `.dark`:
  - `--service-badge-bg`
  - `--service-badge-text`
- ✅ All colors reference CSS variables (no hardcoded colors in components).



### 🎯 Key Enhancements
- **Responsive Design** → Section added using existing responsive layout containers and utility classes.
- **Accessibility** → Section uses semantic `<section>` and ARIA `aria-label="Services"`.
- **Theme Awareness** → Color tokens added for both light and dark themes (`:root` and `.dark`).
- **Design Consistency** → Badge text color uses `--service-badge-text` which references existing navbar/CTA tokens to maintain brand consistency.

---

### 🧪 Testing Checklist
- [ ] Verify the `Service` section renders on the homepage after `FeatureCards` (desktop + mobile).
- [ ] Confirm badge uses `--service-badge-bg` and `--service-badge-text` in light mode.
- [ ] Confirm badge uses `--service-badge-bg` and `--service-badge-text` in dark mode.
- [ ] Ensure the section has no forced background (inherits page background).
- [ ] Snapshot or visual test against design: spacing, typography, contrast.

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Services section to the home page, highlighting auditing offerings for DeFi, NFTs, DAOs, and core infrastructure. Includes clear heading, descriptive text, and an accessible, responsive layout.

* **Style**
  * Introduced theme-aware tokens for the service badge background and text, ensuring consistent styling across light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->