### PR TITLE
feat: add Methodology section badge, title & subtitle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -174,6 +174,9 @@
     0.08
   ); /* subtle blue background by default */
   --service-badge-text: var(--navbar-btn-bg);
+  /* Methodology badge colors (light) */
+  --methodology-badge-bg: rgba(99, 102, 241, 0.08); /* subtle indigo/purple */
+  --methodology-badge-text: #5b21b6; /* indigo-700 like */
   --feature-card-border-hover: #06b6d4; /* cyan-500 fallback for hover */
   --feature-card-icon-bg: rgba(6, 182, 212, 0.08);
   /* Service card icon variables */
@@ -233,6 +236,9 @@
   /* Service section badge colors (dark) */
   --service-badge-bg: rgba(36, 86, 244, 0.08);
   --service-badge-text: var(--navbar-btn-text);
+  /* Methodology badge colors (dark) */
+  --methodology-badge-bg: rgba(99, 102, 241, 0.08);
+  --methodology-badge-text: var(--navbar-btn-text);
   --feature-card-border-hover: #0891b2; /* slightly darker cyan for dark mode */
   --feature-card-icon-bg: rgba(8, 145, 178, 0.08);
   --sidebar: oklch(0.21 0.034 264.665);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
   PortfolioStats,
   JoinMission,
   TrustedLeadingProtocols,
+  MethodologySection,
   PricingSection,
   AuditProcess,
   LatestBlogSection,
@@ -21,6 +22,7 @@ export default function Home() {
       <FeaturePills />
       <FeatureCards />
       <ServiceSection />
+      <MethodologySection />
       <PortfolioStats />
       <AuditProcess />
       <PricingSection />

--- a/src/components/sections/FeatureCardsSection.tsx
+++ b/src/components/sections/FeatureCardsSection.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FileText, Pen, GitMerge, Shield } from 'lucide-react';
+import React from "react";
+import { FileText, Pen, GitMerge, Shield } from "lucide-react";
 
 type Feature = {
   id: string;
@@ -10,35 +10,42 @@ type Feature = {
 
 const FEATURES: Feature[] = [
   {
-    id: 'public-reports',
-    title: 'Public Reports',
+    id: "public-reports",
+    title: "Public Reports",
     description:
-      'Every audit includes reproducible steps and proof-of-concept validations.',
+      "Every audit includes reproducible steps and proof-of-concept validations.",
     Icon: FileText,
   },
   {
-    id: 'battle-tested',
-    title: 'Battle-Tested Methods',
-    description: 'From static analysis to manual review and fuzzing, we cover what matters.',
+    id: "battle-tested",
+    title: "Battle-Tested Methods",
+    description:
+      "From static analysis to manual review and fuzzing, we cover what matters.",
     Icon: Pen,
   },
   {
-    id: 'community',
-    title: 'Community Collaboration',
-    description: 'Engage via issues and PRs to continuously improve security posture.',
+    id: "community",
+    title: "Community Collaboration",
+    description:
+      "Engage via issues and PRs to continuously improve security posture.",
     Icon: GitMerge,
   },
   {
-    id: 'secure-by-default',
-    title: 'Secure by Default',
-    description: 'Practical recommendations to harden deployments and operations.',
+    id: "secure-by-default",
+    title: "Secure by Default",
+    description:
+      "Practical recommendations to harden deployments and operations.",
     Icon: Shield,
   },
 ];
 
 export default function FeatureCardsSection() {
   return (
-    <section aria-label="Feature cards" className="w-full my-20 py-12 md:py-20" style={{ background: 'var(--feature-cards-bg)' }}>
+    <section
+      aria-label="Feature cards"
+      className="w-full my-20 py-12 md:py-20"
+      style={{ background: "var(--feature-cards-bg)" }}
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {FEATURES.map((f) => (
@@ -46,21 +53,33 @@ export default function FeatureCardsSection() {
               key={f.id}
               className="feature-card bg-card border border-border rounded-lg p-6 shadow-sm transition-transform duration-300 will-change-transform min-h-56 md:min-h-64"
               style={{
-                background: 'var(--feature-pill-bg)',
-                boxShadow: 'var(--feature-pill-shadow)',
-                borderRadius: 'var(--radius-xl)',
+                background: "var(--feature-pill-bg)",
+                boxShadow: "var(--feature-pill-shadow)",
+                borderRadius: "var(--radius-xl)",
               }}
             >
               <div className="flex flex-col gap-4 h-full" aria-hidden={false}>
                 <div className="w-10 h-10 flex items-center justify-center rounded-md feature-card-icon-bg">
-                  <f.Icon className="feature-icon" width={20} height={20} aria-hidden="true" style={{ color: 'var(--feature-pill-icon)' }} />
+                  <f.Icon
+                    className="feature-icon"
+                    width={20}
+                    height={20}
+                    aria-hidden="true"
+                    style={{ color: "var(--feature-pill-icon)" }}
+                  />
                 </div>
 
                 <div className="flex-1">
-                  <h3 className="text-lg font-semibold leading-6" style={{ color: 'var(--foreground)' }}>
+                  <h3
+                    className="text-lg font-semibold leading-6"
+                    style={{ color: "var(--foreground)" }}
+                  >
                     {f.title}
                   </h3>
-                  <p className="mt-3 text-sm leading-6 max-w-prose" style={{ color: 'var(--muted-foreground)' }}>
+                  <p
+                    className="mt-3 text-sm leading-6 max-w-prose"
+                    style={{ color: "var(--muted-foreground)" }}
+                  >
                     {f.description}
                   </p>
                 </div>

--- a/src/components/sections/MethodologySection.tsx
+++ b/src/components/sections/MethodologySection.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React from "react";
+
+export function MethodologySection() {
+  return (
+    <section aria-label="Methodology" className="w-full my-20 py-12 md:py-20">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl">
+          <span
+            className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium mb-4"
+            style={{
+              background: "var(--methodology-badge-bg)",
+              color: "var(--methodology-badge-text)",
+              border: "1px solid var(--border)",
+            }}
+          >
+            Methodology
+          </span>
+
+          <h2
+            className="text-3xl sm:text-4xl font-extrabold mb-4"
+            style={{ color: "var(--foreground)" }}
+          >
+            A transparent, stepwise approach designed for rigor and
+            reproducibility.
+          </h2>
+
+          <p
+            className="text-base max-w-prose"
+            style={{ color: "var(--muted-foreground)" }}
+          >
+            We combine automated analysis (e.g., static/dynamic scans, fuzzing)
+            with thorough manual review and reproducible PoCs to produce reports
+            you can trust.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default MethodologySection;

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -12,3 +12,4 @@ export { FeaturePills } from "./FeaturePills";
 export { default as FeatureCards } from "./FeatureCardsSection";
 export { default as WorkingProcess } from "./WorkingProcessSection";
 export { ServiceSection } from "./ServiceSection";
+export { MethodologySection } from "./MethodologySection";


### PR DESCRIPTION

PR description
- Summary
  - Adds a minimal Methodology section to the homepage: badge, section title, and subtitle. Wires the component into the sections barrel and renders it after the Services section. Adds theme-safe CSS variables used by the badge.

- What I changed
  - Added the `MethodologySection` component: MethodologySection.tsx
  - Exported the section from the sections barrel: index.ts
  - Rendered the section on the home page after Services: page.tsx
  - Added badge color vars to the theme: `--methodology-badge-bg` and `--methodology-badge-text` in globals.css

- Why
  - Implements the first PR in the Methodology work: presentational header (badge + copy), using existing theme variables and adding any small color tokens required for parity with the design.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Services section with animated cards, icons, and “Learn more in Methodology” links.
  - Added Methodology section with badge, headline, and descriptive copy.
  - Home page now includes both sections with accessible markup and responsive layouts.

- Style
  - Introduced new light/dark theme tokens for service and methodology badges, plus service card icon styling for improved visual consistency.

- Chores
  - Removed an unused placeholder services section file.
  - Minor formatting updates with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->