### PR TITLE
feat: setup featured reports section with header and subtitle

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import {
   FeaturePills,
   FeatureCards,
   ServiceSection,
+  FeaturedReports,
   WorkingProcess,
   PortfolioStats,
   JoinMission,
@@ -23,6 +24,7 @@ export default function Home() {
       <FeatureCards />
       <ServiceSection />
       <MethodologySection />
+      <FeaturedReports />
       <PortfolioStats />
       <AuditProcess />
       <PricingSection />

--- a/src/components/sections/FeaturedReports.tsx
+++ b/src/components/sections/FeaturedReports.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+export default function FeaturedReports() {
+  return (
+    <section
+      aria-label="Featured reports"
+      className="w-full my-20 py-12"
+      // keep background transparent; colors come from globals.css variables
+      style={{ background: "transparent" }}
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl">
+          <h2
+            className="text-3xl sm:text-4xl font-extrabold leading-tight"
+            style={{ color: "var(--foreground)" }}
+          >
+            Featured Reports
+          </h2>
+
+          <p
+            className="mt-3 text-sm sm:text-base max-w-prose"
+            style={{ color: "var(--muted-foreground)" }}
+          >
+            Read transparent, reproducible reports across DeFi, NFTs, DAOs,
+            infra and more.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -13,3 +13,4 @@ export { default as FeatureCards } from "./FeatureCardsSection";
 export { default as WorkingProcess } from "./WorkingProcessSection";
 export { ServiceSection } from "./ServiceSection";
 export { MethodologySection } from "./MethodologySection";
+export { default as FeaturedReports } from "./FeaturedReports";


### PR DESCRIPTION

### PR description
- What: Add the Featured Reports section header and subtitle and wire the new section into the homepage.
- Files changed:
  - FeaturedReports.tsx — new minimal section with title + subtitle using CSS variables (`var(--foreground)`, `var(--muted-foreground)`).
  - index.ts — export `FeaturedReports`.
  - page.tsx — render `<FeaturedReports />` directly after `<MethodologySection />`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a new “Featured Reports” section to the Home page, with a header and descriptive copy.
  * Positioned between the Methodology and Portfolio Stats sections.
  * Uses accessible markup and theme-aware colors.
  * Responsive layout with constrained widths; background remains transparent.
  * No changes to existing sections’ behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->