### PR TITLE
feat: update OpenSourceSection with badge styling and content

### DIFF
--- a/src/components/sections/OpenSourceSection.tsx
+++ b/src/components/sections/OpenSourceSection.tsx
@@ -41,20 +41,27 @@ export function OpenSourceSection() {
           <div className="lg:col-span-7">
             {/* Small badge / label */}
             <div className="mb-3">
-              {/* Badge placeholder: insert small label/pill (e.g. "Open Source") */}
-              <span className="inline-block rounded-full px-3 py-1 text-xs font-medium bg-slate-100 text-slate-700">
-                {/* TODO: insert badge text or component */}
+              {/* Use CSS variables from globals.css for badge background and text color */}
+              <span
+                className="inline-block rounded-full px-3 py-1 text-xs font-medium"
+                style={{
+                  background: "var(--service-badge-bg)",
+                  color: "var(--service-badge-text)",
+                }}
+              >
+                Open Source
               </span>
             </div>
 
             {/* Heading */}
             <h2 className="text-3xl sm:text-4xl font-extrabold leading-tight text-foreground">
-              {/* TODO: Insert heading/title for the Open Source section */}
+              Built in public. Contributions welcome.
             </h2>
 
             {/* Intro paragraph */}
             <p className="mt-3 text-sm sm:text-base text-muted-foreground max-w-prose">
-              {/* TODO: Insert intro paragraph or short description */}
+              We value transparency and reproducibility. Read our guidelines,
+              open issues, submit PRs, and help shape open auditing practices.
             </p>
 
             {/* Action buttons */}


### PR DESCRIPTION
### PR description
- Summary:
  - Adds the Open Source badge, the section heading "Built in public. Contributions welcome.", and the intro subtitle copy to the Open Source section.
  - Ensures colors come from CSS variables (no hardcoded color values).
- Files changed:
  - OpenSourceSection.tsx — populated badge text, heading, and paragraph; applied styling using CSS variables.
- Color handling:
  - Uses existing variables `--service-badge-bg` and `--service-badge-text` from globals.css. No hardcoded colors introduced and no new variables were required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Open Source badge to follow theme colors for improved visual consistency.
* **Content**
  * Replaced placeholder heading with “Built in public. Contributions welcome.”
  * Added clearer introductory copy highlighting transparency, guidelines, issues, and PRs.
* **Chores**
  * Kept layout and calls-to-action unchanged for future wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->