### PR TITLE
feat: open source section CTA styling

### DIFF
--- a/src/components/sections/OpenSourceSection.tsx
+++ b/src/components/sections/OpenSourceSection.tsx
@@ -66,10 +66,18 @@ export function OpenSourceSection() {
 
             {/* Action buttons */}
             <div className="mt-6 flex flex-wrap items-center gap-3">
-              {/* Primary CTA - Contribute on GitHub */}
-              <Button asChild size="default" className="rounded-md">
-                <Link href="#" aria-label="Primary action">
-                  {/* TODO: Primary CTA label (e.g. "Contribute on GitHub") */}
+              {/* Primary CTA - Contribute on GitHub (uses navbar CTA CSS variables) */}
+              <Button
+                asChild
+                size="default"
+                className="rounded-md"
+                style={{
+                  background: "var(--navbar-btn-bg)",
+                  color: "var(--navbar-btn-text)",
+                }}
+              >
+                <Link href="#" aria-label="Contribute on GitHub">
+                  Contribute on GitHub
                 </Link>
               </Button>
 
@@ -80,8 +88,8 @@ export function OpenSourceSection() {
                 size="default"
                 className="rounded-md"
               >
-                <Link href="#" aria-label="Secondary action">
-                  {/* TODO: Secondary CTA label (e.g. "Security Policy") */}
+                <Link href="#" aria-label="Security Policy">
+                  Security Policy
                 </Link>
               </Button>
 
@@ -91,17 +99,24 @@ export function OpenSourceSection() {
                 size="default"
                 className="rounded-md"
               >
-                <Link href="#" aria-label="Secondary action">
-                  {/* TODO: Secondary CTA label (e.g. "Responsible Disclosure") */}
+                <Link href="#" aria-label="Responsible Disclosure">
+                  Responsible Disclosure
                 </Link>
               </Button>
 
-              {/* Tertiary small button */}
-              <Button asChild variant="ghost" size="sm" className="mt-2">
-                <Link href="#" aria-label="Tertiary action">
-                  {/* TODO: Tertiary CTA label (e.g. "Join the Discussion") */}
-                </Link>
-              </Button>
+              {/* Tertiary button: same outline style as other secondary actions, placed on its own line */}
+              <div className="w-full mt-2">
+                <Button
+                  asChild
+                  variant="outline"
+                  size="default"
+                  className="rounded-md"
+                >
+                  <Link href="#" aria-label="Join the Discussion">
+                    Join the Discussion
+                  </Link>
+                </Button>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION

### PR description
- Summary
  - Use global CSS variables for the primary "Contribute on GitHub" CTA so it matches the navbar CTA in both light and dark modes.
  - Add visible labels for secondary CTAs.
  - Make "Join the Discussion" use the same outline style as other secondary buttons and place it on its own line.

- Why
  - Keep color tokens centralized (no hardcoded colors).
  - Improve visual consistency with the navbar CTA and other action buttons.
  - Ensure dark mode follows the same variables.

- What changed
  - Updated OpenSourceSection.tsx:
    - Primary CTA now uses: `background: var(--navbar-btn-bg)` and `color: var(--navbar-btn-text)`.
    - Added labels: "Contribute on GitHub", "Security Policy", "Responsible Disclosure", "Join the Discussion".
    - "Join the Discussion" converted to `variant="outline"` and wrapped in a `div.w-full.mt-2` so it renders on the next line.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an Open Source section to the Home page with a badge, heading, intro text, primary/secondary CTAs, and a placeholder GitHub stats card. Responsive and accessible.

- Style
  - Redesigned Service cards with a cleaner article-based layout, improved icon treatment, typography, and contrast. Enhanced focus states and labels for better accessibility while keeping the existing grid and content intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->