### PR TITLE
feat: enhance os stat tile dark mode friendly

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,6 +132,9 @@
   --navbar-logo-blue: #2456f4;
   --navbar-btn-bg: #2456f4;
   --navbar-btn-text: #fff;
+  /* Open source stat tile colors - light: card with foreground text and border; dark: overridden in .dark */
+  --opensource-stat-bg: var(--card);
+  --opensource-stat-text: var(--foreground);
   --navbar-github-bg: #fff;
   --navbar-github-border: #e5e7eb;
   --navbar-github-shadow: 0 8px 20px rgba(2, 6, 23, 0.06);
@@ -202,6 +205,9 @@
   --navbar-logo-blue: #2456f4; /* use same blue as light mode */
   --navbar-btn-bg: #2456f4; /* CTA same blue in dark */
   --navbar-btn-text: #ffffff; /* white text on blue CTA */
+  /* Open source stat tile colors (dark) - CTA blue background with white text */
+  --opensource-stat-bg: var(--navbar-btn-bg);
+  --opensource-stat-text: var(--navbar-btn-text);
   --navbar-github-bg: #000000;
   --navbar-github-border: #27272a;
   --navbar-github-shadow: 0 8px 20px rgba(2, 6, 23, 0.36);

--- a/src/components/sections/OpenSourceSection.tsx
+++ b/src/components/sections/OpenSourceSection.tsx
@@ -216,15 +216,31 @@ export function OpenSourceSection() {
                   return (
                     <div
                       key={stat.id}
-                      className="rounded-md border bg-background p-4 text-center"
+                      className="rounded-md p-4 text-center"
+                      style={{
+                        background: "var(--opensource-stat-bg)",
+                        color: "var(--opensource-stat-text)",
+                        border: "1px solid var(--border)",
+                      }}
                     >
-                      <div className="flex justify-center mb-2 text-muted-foreground">
+                      <div
+                        className="flex justify-center mb-2"
+                        style={{ color: "var(--opensource-stat-text)" }}
+                      >
                         <Icon className="w-5 h-5" />
                       </div>
-                      <div className="text-xs text-muted-foreground">
+                      <div
+                        className="text-xs"
+                        style={{ color: "var(--opensource-stat-text)" }}
+                      >
                         {stat.label}
                       </div>
-                      <div className="mt-2 font-bold">{stat.value ?? 0}</div>
+                      <div
+                        className="mt-2 font-bold"
+                        style={{ color: "var(--opensource-stat-text)" }}
+                      >
+                        {stat.value ?? 0}
+                      </div>
                     </div>
                   );
                 })}


### PR DESCRIPTION
### PR description
- Summary
  - Make Stars / Forks / Issues tiles use the navbar CTA color in dark mode and show a bordered card appearance in light mode. Introduces two theme variables and wires the Open Source stats UI to them.

- What changed
  - Added theme variables to globals.css
    - `--opensource-stat-bg` (light: `var(--card)`, dark: `var(--navbar-btn-bg)`)
    - `--opensource-stat-text` (light: `var(--foreground)`, dark: `var(--navbar-btn-text)`)
  - Updated OpenSourceSection.tsx
    - Stat tiles now consume the new variables for background and text and include `border: 1px solid var(--border)` to match the light-mode screenshot.


- Behavior / Design notes
  - Light mode: tiles look like the attached screenshot — card background + subtle border + foreground text.
  - Dark mode: tiles use the navbar CTA blue background and white text (same as "Request an Audit" button).
  - No change to data fetching or functionality; purely UI styling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an Open Source section to the Home page with a stats tile and quick links (Contribute, Security Policy, Responsible Disclosure, Discussion).
* Style
  * Updated theme tokens to support Open Source stat tile colors in light and dark modes.
  * Refreshed Services section visuals with cleaner layout, updated icons, and improved typography.
* Accessibility
  * Services items are now semantic articles with clearer labeling and better keyboard focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->