### PR TITLE
feat: featured reports scrollable carousel

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,16 @@
   z-index: 1;
 }
 
+/* Hide scrollbar for featured reports */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 @media (min-width: 640px) {
   .ready-secure-card {
     max-width: 900px;

--- a/src/components/sections/FeaturedReports.tsx
+++ b/src/components/sections/FeaturedReports.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import { useRef } from "react";
+import { ChevronLeft, ChevronRight, ExternalLink } from "lucide-react";
+
 export type Report = {
   id: string;
   title: string;
@@ -7,6 +12,8 @@ export type Report = {
 };
 
 export default function FeaturedReports() {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
   const reports: Report[] = [
     {
       id: "deltaswap-v2",
@@ -32,7 +39,49 @@ export default function FeaturedReports() {
       tags: ["DAO", "Governance"],
       href: "#",
     },
+    {
+      id: "uniswap-v4",
+      title: "Uniswap v4",
+      description:
+        "Hook architecture security, position manager, core pool functionality audit.",
+      tags: ["DeFi", "AMM", "Hooks"],
+      href: "#",
+    },
+    {
+      id: "polygon-zkevm",
+      title: "Polygon zkEVM",
+      description:
+        "Zero-knowledge proof system, state transition verification, bridge security.",
+      tags: ["L2", "ZK", "Bridge"],
+      href: "#",
+    },
+    {
+      id: "compound-v3",
+      title: "Compound v3",
+      description:
+        "Lending protocol security, interest rate model, liquidation mechanisms.",
+      tags: ["DeFi", "Lending", "Oracle"],
+      href: "#",
+    },
   ];
+
+  const scrollLeft = () => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollBy({
+        left: -320,
+        behavior: "smooth",
+      });
+    }
+  };
+
+  const scrollRight = () => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollBy({
+        left: 320,
+        behavior: "smooth",
+      });
+    }
+  };
 
   return (
     <section
@@ -59,68 +108,110 @@ export default function FeaturedReports() {
         </div>
 
         <div className="mt-8">
-          <div className="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {reports.map((r) => (
-              <article
-                key={r.id}
-                aria-labelledby={`${r.id}-title`}
-                className="feature-card bg-card border border-border rounded-lg p-6 shadow-sm transition-transform duration-300 will-change-transform focus:outline-none focus-visible:ring"
+          <div className="relative">
+            {/* Navigation buttons */}
+            <div className="absolute -top-12 right-0 flex gap-2 z-10">
+              <button
+                onClick={scrollLeft}
+                className="p-2 rounded-lg border transition-colors duration-200"
                 style={{
-                  background: "var(--feature-pill-bg)",
-                  boxShadow: "var(--feature-pill-shadow)",
-                  borderRadius: "var(--radius-lg)",
+                  background: "var(--card)",
+                  borderColor: "var(--border)",
+                  color: "var(--foreground)",
                 }}
+                aria-label="Scroll left"
               >
-                <div className="flex flex-col h-full">
-                  <div className="flex-1">
-                    <h3
-                      id={`${r.id}-title`}
-                      className="text-lg font-semibold leading-6"
-                      style={{ color: "var(--foreground)" }}
-                    >
-                      {r.title}
-                    </h3>
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <button
+                onClick={scrollRight}
+                className="p-2 rounded-lg border transition-colors duration-200"
+                style={{
+                  background: "var(--card)",
+                  borderColor: "var(--border)",
+                  color: "var(--foreground)",
+                }}
+                aria-label="Scroll right"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
 
-                    <p
-                      className="mt-3 text-sm leading-6 max-w-prose"
-                      style={{ color: "var(--muted-foreground)" }}
-                    >
-                      {r.description}
-                    </p>
+            {/* Scrollable container */}
+            <div
+              ref={scrollContainerRef}
+              className="mt-10 flex gap-6 overflow-x-auto scrollbar-hide pb-4 px-4"
+              style={{
+                scrollbarWidth: "none",
+                msOverflowStyle: "none",
+              }}
+            >
+              {reports.map((r) => (
+                <article
+                  key={r.id}
+                  aria-labelledby={`${r.id}-title`}
+                  className="feature-card border rounded-lg p-6 shadow-sm transition-transform duration-300 will-change-transform focus:outline-none focus-visible:ring flex-none"
+                  style={{
+                    background: "var(--feature-pill-bg)",
+                    boxShadow: "var(--feature-pill-shadow)",
+                    borderRadius: "var(--radius-lg)",
+                    borderColor: "var(--border)",
+                    minWidth: "300px",
+                    width: "300px",
+                  }}
+                >
+                  <div className="flex flex-col h-full">
+                    <div className="flex-1">
+                      <h3
+                        id={`${r.id}-title`}
+                        className="text-lg font-semibold leading-6"
+                        style={{ color: "var(--foreground)" }}
+                      >
+                        {r.title}
+                      </h3>
 
-                    <ul className="mt-4 flex flex-wrap gap-2" role="list">
-                      {r.tags.map((t) => (
-                        <li
-                          key={t}
-                          className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium"
-                          style={{
-                            background: "var(--service-badge-bg)",
-                            color: "var(--service-badge-text)",
-                            border: "1px solid var(--border)",
-                          }}
-                        >
-                          {t}
-                        </li>
-                      ))}
-                    </ul>
+                      <p
+                        className="mt-3 text-sm leading-6 max-w-prose"
+                        style={{ color: "var(--muted-foreground)" }}
+                      >
+                        {r.description}
+                      </p>
+
+                      <ul className="mt-4 flex flex-wrap gap-2" role="list">
+                        {r.tags.map((t) => (
+                          <li
+                            key={t}
+                            className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium"
+                            style={{
+                              background: "var(--service-badge-bg)",
+                              color: "var(--service-badge-text)",
+                              border: "1px solid var(--border)",
+                            }}
+                          >
+                            {t}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    <div className="mt-4 flex justify-end">
+                      <a
+                        href={r.href}
+                        {...(r.href && r.href !== "#"
+                          ? { target: "_blank", rel: "noopener noreferrer" }
+                          : {})}
+                        aria-label={`Read report: ${r.title}`}
+                        className="text-sm font-medium flex items-center gap-1"
+                        style={{ color: "var(--navbar-btn-bg)" }}
+                      >
+                        Read Report
+                        <ExternalLink className="w-3 h-3" />
+                      </a>
+                    </div>
                   </div>
-
-                  <div className="mt-4 flex justify-end">
-                    <a
-                      href={r.href}
-                      {...(r.href && r.href !== "#"
-                        ? { target: "_blank", rel: "noopener noreferrer" }
-                        : {})}
-                      aria-label={`Read report: ${r.title}`}
-                      className="text-sm font-medium"
-                      style={{ color: "var(--navbar-btn-bg)" }}
-                    >
-                      Read Report 
-                    </a>
-                  </div>
-                </div>
-              </article>
-            ))}
+                </article>
+              ))}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
PR description
Summary
- Convert Featured Reports into a horizontally scrollable card carousel.
- Add three additional report cards (Uniswap v4, Polygon zkEVM, Compound v3).
- Add left/right navigation buttons (positioned top-right, raised ~50px).
- Add an ExternalLink icon to the right of the "Read Report" link using `lucide-react`.
- Keep all colors sourced from existing CSS variables; no new color tokens added to globals.css.
- Add `px` padding to the scroller container and hide the scrollbar for visual cleanliness.

Files modified
- FeaturedReports.tsx
  - Added 3 new reports to the data array.
  - Reworked layout to a horizontally scrollable flex container with `overflow-x-auto`.
  - Added left and right nav buttons that call `scrollBy({ left: ±320, behavior: "smooth" })`.
  - Added `ExternalLink` icon from `lucide-react` next to "Read Report".
  - All color styling uses existing CSS variables (e.g., `var(--foreground)`, `var(--border)`, etc.)
- globals.css
  - Added `.scrollbar-hide` helper to hide native scrollbar (uses existing CSS context; no new color variables).

Why
- Improves discoverability and layout consistency for featured reports on narrow viewports.
- Matches the requested design with navigation affordances for horizontal lists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a horizontal carousel for Featured Reports with left/right navigation.
  * Displays reports as cards with titles, descriptions, tags, and a “Read Report” link opening in a new tab when available.
  * Improved accessibility with ARIA labels and semantic list roles.

* **Style**
  * Scrollbars are hidden in supported browsers for a cleaner, more immersive carousel experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->