### PR TITLE
feat: make FeaturePills static and remove hover/focus interactions and clean globals.css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -395,24 +395,14 @@
   .shadow-feature-pill {
     box-shadow: var(--feature-pill-shadow);
   }
-  .shadow-feature-pill-hover:hover {
-    box-shadow: var(--feature-pill-shadow-hover);
-  }
+  /* feature pill base shadow and icon color - hover/transition removed to make pills static */
   .feature-pill-link {
-    will-change: transform, box-shadow;
+    /* keep layout/appearance helpers only */
     backface-visibility: hidden;
     transform: translateZ(0);
-    transition: transform 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
-      box-shadow 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
   }
   .feature-pill-link .feature-pill-icon {
-    transition: transform 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
-      color 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
     color: var(--feature-pill-icon);
-  }
-  .feature-pill-link:hover .feature-pill-icon {
-    transform: translateY(-2px) scale(1.04);
-    color: var(--feature-pill-icon-hover);
   }
 
   /* Feature card hover and icon utilities (used by FeatureCardsSection) */

--- a/src/components/sections/FeaturePills.tsx
+++ b/src/components/sections/FeaturePills.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { memo } from "react";
 import { Shield, FileText, Users, Columns } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 type Feature = {
   id: string;
@@ -15,7 +16,41 @@ const DEFAULT_FEATURES: Feature[] = [
   { id: "evm-focused", title: "EVM Focused", Icon: Columns },
 ];
 
-export function FeaturePills({
+const FeaturePill = ({ feature }: { feature: Feature }) => {
+  const { id, title, Icon, href } = feature;
+
+  return (
+    <li key={id}>
+      <a
+        href={href ?? "#"}
+        aria-label={title}
+        className={cn(
+          "feature-pill-link inline-flex items-center gap-3 px-6 py-3 rounded-lg border shadow-feature-pill"
+        )}
+        // Keep visual tokens as inline style so theming variables remain easy to override
+        style={{
+          background: "var(--feature-pill-bg)",
+          borderColor: "var(--feature-pill-border)",
+          color: "var(--feature-pill-text)",
+          minHeight: 44,
+        }}
+      >
+        <span className="flex items-center justify-center" aria-hidden="true">
+          <Icon
+            width={18}
+            height={18}
+            className="feature-pill-icon"
+            aria-hidden="true"
+          />
+        </span>
+
+        <span className="text-sm font-medium leading-none">{title}</span>
+      </a>
+    </li>
+  );
+};
+
+export const FeaturePills = memo(function FeaturePills({
   features = DEFAULT_FEATURES,
 }: {
   features?: Feature[];
@@ -28,38 +63,11 @@ export function FeaturePills({
         className="flex flex-wrap gap-6 items-center justify-center max-w-5xl px-4"
       >
         {features.map((f) => (
-          <li key={f.id}>
-            <a
-              href={f.href ?? "#"}
-              className="feature-pill-link inline-flex items-center gap-3 px-6 py-3 rounded-lg border shadow-feature-pill transition-shadow transform duration-200 ease-out hover:shadow-feature-pill-hover hover:-translate-y-1 hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-              style={{
-                background: "var(--feature-pill-bg)",
-                borderColor: "var(--feature-pill-border)",
-                color: "var(--feature-pill-text)",
-                minHeight: 44,
-              }}
-              aria-label={f.title}
-            >
-              <span
-                className="flex items-center justify-center"
-                aria-hidden="true"
-              >
-                <f.Icon
-                  width={18}
-                  height={18}
-                  aria-hidden="true"
-                  className="feature-pill-icon"
-                />
-              </span>
-              <span className="text-sm font-medium leading-none">
-                {f.title}
-              </span>
-            </a>
-          </li>
+          <FeaturePill key={f.id} feature={f} />
         ))}
       </ul>
     </div>
   );
-}
+});
 
 export default FeaturePills;


### PR DESCRIPTION


## PR description
Summary
- Remove hover / focus interactions from the FeaturePills UI and clean up unused pill-specific CSS in globals.css.
- Replace FeaturePills.tsx with a concise, typed, memoized, production-ready implementation that preserves layout, theme tokens and accessibility but no longer uses hover/focus transforms or shadow transitions.
- Remove pill-specific hover selectors and transitions from globals.css while keeping shared variables and feature-card hover behaviour intact.

What  changed
- FeaturePills.tsx
  - Rewritten to a small, typed, memoized component.
  - Removed hover/focus utility classes (no translate/scale/transition/hover shadow).
  - Kept CSS variable usage for background/border/text and the `shadow-feature-pill` base class.
- globals.css
  - Removed pill-specific hover/transition selectors:
    - removed `.shadow-feature-pill-hover:hover`
    - removed `.feature-pill-link` transition/hover transform rules and `.feature-pill-link:hover .feature-pill-icon`
  - Kept:
    - base `.shadow-feature-pill` and `.feature-pill-link .feature-pill-icon`
    - CSS variables such as `--feature-pill-icon-hover` and `--feature-pill-shadow-hover` (retained because other components — e.g., `.feature-card` — still rely on them)
    - `.feature-card` hover rules (unchanged)

Why
- The FeaturePills design should be visually static (no hover/focus motion). Removing the interactive classes reduces unexpected motion and keeps the layout consistent with the current design request.
- Kept shared tokens to avoid breaking other sections that intentionally rely on hover states (FeatureCards, etc.).
