### PR TITLE
feat: update HeroSection styles and make button responsive 

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -7,11 +7,11 @@ export function HeroSection() {
   return (
     <section
       aria-label="OpenAuditLabs hero"
-      className="hero-section w-full bg-background min-h-screen pb-[100px]"
+      className="hero-section w-full bg-background min-h-screen pb-[100px] mb-5"
     >
       <div className="mx-auto max-w-7xl px-4 py-20 sm:py-28 lg:py-36 flex items-start">
         <div className="max-w-3xl mx-auto text-center -mt-16">
-          <h1 className="font-extrabold tracking-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl leading-tight text-foreground">
+          <h1 className="font-extrabold tracking-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl leading-tight text-foreground mt-22 md:mt-0 ">
             <span className="block">Open-source</span>
             <span
               className="block hero-heading-gradient-cta font-extrabold"
@@ -39,8 +39,8 @@ export function HeroSection() {
               <span className="hero-cta-glow rounded-lg" aria-hidden="true" />
               <Button
                 asChild
-                size="lg"
-                className="relative z-10 rounded-lg px-6 py-3 font-semibold shadow-md"
+                size="hero"
+                className="relative z-10 font-semibold shadow-md"
                 style={{
                   backgroundColor: "var(--hero-cta-bg)",
                   color: "var(--hero-cta-text)",
@@ -58,8 +58,8 @@ export function HeroSection() {
             <Button
               asChild
               variant="outline"
-              size="lg"
-              className="rounded-lg px-5 py-3 border-[1.5px] text-foreground/90"
+              size="heroOutlineMobile"
+              className="border-[1.5px] text-foreground/90"
             >
               <Link href="/" aria-label="View on GitHub">
                 <span className="flex items-center gap-2">

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -11,7 +11,7 @@ export function HeroSection() {
     >
       <div className="mx-auto max-w-7xl px-4 py-20 sm:py-28 lg:py-36 flex items-start">
         <div className="max-w-3xl mx-auto text-center -mt-16">
-          <h1 className="font-extrabold tracking-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl leading-tight text-foreground mt-22 md:mt-0 ">
+          <h1 className="font-extrabold tracking-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl leading-tight text-foreground mt-[5.5rem] md:mt-0 ">
             <span className="block">Open-source</span>
             <span
               className="block hero-heading-gradient-cta font-extrabold"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -26,6 +26,10 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        // hero sizes used for the site hero component
+        hero: "rounded-lg px-6 py-2 sm:py-3 text-base has-[>svg]:px-3",
+        heroOutlineMobile:
+          "rounded-lg px-5 py-4 sm:py-3 text-base has-[>svg]:px-3 w-full sm:w-auto",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
### PR description
## Summary
Centralize hero-specific button sizing in the shared `Button` component and update the Hero to use those variants so the "View on GitHub" button becomes full-width on mobile and the CTAs use consistent, responsive heights. No hardcoded colors were added and no global CSS modified.

## Why
- Reduce duplicated inline spacing classes.
- Make the hero CTA sizing reusable and easier to tweak.
- Match requested mobile behaviour (GitHub button full-width + responsive height adjustments) while keeping colors driven by existing CSS variables.

## What  changed
- button.tsx — added two reusable size variants:
  - `hero` — used for the primary hero CTA.
  - `heroOutlineMobile` — used for the outline GitHub CTA (full-width on mobile).
  These variants centralize padding/height and w/full rules so the Hero layout is maintainable.
- HeroSection.tsx — switched the CTA buttons to use the new `size` variants and removed duplicated inline padding/width classes. Preserved existing color usage via CSS variables (`var(--hero-cta-bg)`, `var(--hero-cta-text)`) — no hardcoded colors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Improved hero section spacing for better visual balance, adding bottom margin and responsive heading spacing.
  - Refined primary and secondary call-to-action buttons with new responsive size variants and adjusted padding for clearer hierarchy.
  - Enhanced mobile experience: secondary CTA becomes full-width on small screens for easier tapping and consistent touch targets.
  - Overall, the hero area now presents a cleaner, more consistent look across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->