### PR TITLE
feat: enhance FeaturePills component with improved responsive layout 

### DIFF
--- a/src/components/sections/FeaturePills.tsx
+++ b/src/components/sections/FeaturePills.tsx
@@ -20,12 +20,12 @@ const FeaturePill = ({ feature }: { feature: Feature }) => {
   const { id, title, Icon, href } = feature;
 
   return (
-    <li key={id}>
+    <li key={id} className="w-full sm:w-auto">
       <a
         href={href ?? "#"}
         aria-label={title}
         className={cn(
-          "feature-pill-link inline-flex items-center gap-3 px-6 py-3 rounded-lg border shadow-feature-pill"
+          "feature-pill-link flex items-center gap-3 px-4 py-3 rounded-lg border shadow-feature-pill w-full overflow-hidden"
         )}
         // Keep visual tokens as inline style so theming variables remain easy to override
         style={{
@@ -35,7 +35,10 @@ const FeaturePill = ({ feature }: { feature: Feature }) => {
           minHeight: 44,
         }}
       >
-        <span className="flex items-center justify-center" aria-hidden="true">
+        <span
+          className="flex items-center justify-center flex-none"
+          aria-hidden="true"
+        >
           <Icon
             width={18}
             height={18}
@@ -44,7 +47,9 @@ const FeaturePill = ({ feature }: { feature: Feature }) => {
           />
         </span>
 
-        <span className="text-sm font-medium leading-none">{title}</span>
+        <span className="text-xs sm:text-sm font-medium leading-none flex-1 text-center truncate">
+          {title}
+        </span>
       </a>
     </li>
   );
@@ -60,7 +65,7 @@ export const FeaturePills = memo(function FeaturePills({
       <ul
         role="list"
         aria-label="Feature highlights"
-        className="flex flex-wrap gap-6 items-center justify-center max-w-5xl px-4"
+        className="grid grid-cols-2 gap-6 justify-items-stretch items-center justify-center max-w-5xl px-4 sm:flex sm:flex-wrap sm:justify-center"
       >
         {features.map((f) => (
           <FeaturePill key={f.id} feature={f} />


### PR DESCRIPTION


## PR description
Problem
- On small screens the FeaturePills layout stacked unevenly and pill labels wrapped to second lines, producing uneven widths and poor readability.

What  changed
- Make the feature list use a 2-column grid on mobile so there are always two columns.
- Make each pill equal-width on mobile (anchors/containers stretch to fill their grid cell).
- Reduce pill text size on mobile and add truncation to avoid wrapping.
- Ensure icon does not shrink and pills keep consistent spacing.

Files changed
- FeaturePills.tsx — use `grid-cols-2` with stretched items on mobile; anchors become full-width; icon/title spacing and truncation added.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Feature Pills to a two-column grid with responsive fallback for small screens.
  * Made pills full-width on mobile, with refined padding, alignment, and spacing.
  * Centered and truncated titles for cleaner presentation and readability.

* **Bug Fixes**
  * Prevented text overflow and icon stretching within pills.
  * Ensured content remains within boundaries and maintains consistent sizing across viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->