### PR TITLE
feat: enhance OpenSourceSection with improved button layout 

### DIFF
--- a/src/components/sections/OpenSourceSection.tsx
+++ b/src/components/sections/OpenSourceSection.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Star, GitBranch, Bug, MessageSquare, Shield } from "lucide-react";
+import {
+  Star,
+  GitBranch,
+  Bug,
+  MessageSquare,
+  Shield,
+  Github,
+} from "lucide-react";
 
 // --- GitHub stats data shapes and placeholders -------------------------------------------------
 // We export simple, well-typed arrays so the UI can render the stats card and notes.
@@ -132,19 +139,24 @@ export function OpenSourceSection() {
               open issues, submit PRs, and help shape open auditing practices.
             </p>
 
-            {/* Action buttons */}
-            <div className="mt-6 flex flex-wrap items-center gap-3">
-              {/* Primary CTA - Contribute on GitHub (uses navbar CTA CSS variables) */}
+            {/* Action buttons: 2-column grid on small screens; lg uses a 3-column grid so Join sits on row 2 centered */}
+            <div className="mt-6 grid grid-cols-2 gap-3 lg:grid-cols-3 lg:items-center">
+              {/* Primary CTA - Contribute on GitHub (fills grid cell on mobile) */}
               <Button
                 asChild
                 size="default"
-                className="rounded-md"
+                className="w-full sm:w-auto rounded-md"
                 style={{
                   background: "var(--navbar-btn-bg)",
                   color: "var(--navbar-btn-text)",
                 }}
               >
-                <Link href="#" aria-label="Contribute on GitHub">
+                <Link
+                  href="#"
+                  aria-label="Contribute on GitHub"
+                  className="inline-flex items-center"
+                >
+                  <Github className="w-4 h-4 mr-2" />
                   Contribute on GitHub
                 </Link>
               </Button>
@@ -154,7 +166,7 @@ export function OpenSourceSection() {
                 asChild
                 variant="outline"
                 size="default"
-                className="rounded-md"
+                className="w-full sm:w-auto rounded-md"
               >
                 <Link href="#" aria-label="Security Policy">
                   Security Policy
@@ -165,26 +177,24 @@ export function OpenSourceSection() {
                 asChild
                 variant="outline"
                 size="default"
-                className="rounded-md"
+                className="w-full sm:w-auto rounded-md"
               >
                 <Link href="#" aria-label="Responsible Disclosure">
                   Responsible Disclosure
                 </Link>
               </Button>
 
-              {/* Tertiary button: same outline style as other secondary actions, placed on its own line */}
-              <div className="w-full mt-2">
-                <Button
-                  asChild
-                  variant="outline"
-                  size="default"
-                  className="rounded-md"
-                >
-                  <Link href="#" aria-label="Join the Discussion">
-                    Join the Discussion
-                  </Link>
-                </Button>
-              </div>
+              {/* Tertiary action - Join the Discussion (placed on row 2, centered column on lg) */}
+              <Button
+                asChild
+                variant="outline"
+                size="default"
+                className="w-full sm:w-auto rounded-md lg:col-start-1 lg:col-span-1 lg:mt-2 lg:justify-self-start"
+              >
+                <Link href="#" aria-label="Join the Discussion">
+                  Join the Discussion
+                </Link>
+              </Button>
             </div>
           </div>
 


### PR DESCRIPTION

### PR description
Summary
- Improve the responsive layout of the Open Source section buttons and add a GitHub icon to the primary CTA to match design intent.
- Keeps desktop layout readable while showing a 2-column button layout on small screens.

What  changed
- Updated OpenSourceSection.tsx
  - Replaced the previous single flex layout with a responsive grid so buttons render as two columns on mobile and a 3-column arrangement on large screens.
  - Ensured the "Join the Discussion" action appears on a second row at desktop but remains left-aligned (start).
  - Added the `Github` icon from `lucide-react` inside the "Contribute on GitHub" button and adjusted spacing.

Why
- Mobile UX: two-column buttons improve tap targets and visual balance.
- Desktop UX: preserves the existing multi-button appearance but prevents the join action from taking the full width.
- Visual: icon makes the primary CTA more recognizable and consistent with other GitHub links.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Open Source section with a responsive grid for action buttons (2 columns on small screens, 3 on large).
  * Contribute on GitHub button now includes a GitHub icon and improved icon-text alignment.
  * Action buttons adapt to screen size: full-width on mobile, auto width on larger screens.
  * “Join the Discussion” integrated into the grid with refined placement for better visual balance and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->