### PR TITLE
feat: add shadcn Input component with customizable styles and props

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }


### PR DESCRIPTION

### **PR Description:**
 **Summary** 
 
- Integrated the `input` component from shadcn UI using `npx shadcn@latest add input`.
- Added new files and updated relevant imports to support the new input component.
- This enhances the UI library and enables consistent input styling across the application.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a standardized input field used across the app for consistent look and behavior.
  * Supports all common input types and integrates seamlessly with existing forms.
  * Improves accessibility and keyboard navigation out of the box.
  * Allows custom styling while preserving default design tokens for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->