### PR TITLE
feat: add next-themes dependency for theme management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.541.0",
         "next": "15.5.0",
+        "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.62.0",
@@ -4830,6 +4831,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.541.0",
     "next": "15.5.0",
+    "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",


### PR DESCRIPTION
## PR Description
This PR adds the `next-themes` dependency to enable theme management in the Next.js application. The `next-themes` library provides a simple way to implement light/dark mode switching and theme persistence.

## Changes
- Added `next-themes@^0.4.6` to package.json dependencies
- Updated package-lock.json with the new dependency

## Usage
developers can use the ThemeProvider and useTheme hook from next-themes to implement theme switching functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a theme management library to enable consistent light/dark/system appearance handling across the app.
  * This change is infrastructure-only; no new user-facing controls or settings are introduced in this release.
  * Lays groundwork for future appearance preferences and automatic theme synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->