### PR TITLE
feat: add initial Features component 

### DIFF
--- a/src/app/(landing)/features/features.tsx
+++ b/src/app/(landing)/features/features.tsx
@@ -1,1 +1,45 @@
-//  landing revolutionary features will be here
+type Feature = {
+  id?: string;
+  title: string;
+  description?: string;
+};
+
+type Props = {
+  features: Feature[];
+};
+
+export default function Features({ features }: Props) {
+  return (
+    <section aria-label="Features" className="py-8">
+      <div className="mx-auto max-w-6xl px-4">
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((f, i) => (
+            <article
+              key={f.id ?? i}
+              className="rounded-md p-4 shadow-sm"
+              style={{
+                backgroundColor: "var(--card)",
+                color: "var(--foreground)",
+              }}
+            >
+              <h3
+                className="text-lg font-semibold"
+                style={{ color: "var(--primary)" }}
+              >
+                {f.title}
+              </h3>
+              {f.description ? (
+                <p
+                  className="mt-2 text-sm"
+                  style={{ color: "var(--muted-foreground)" }}
+                >
+                  {f.description}
+                </p>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### PR description
- Summary
  - Adds a very small, initial `Features` component that accepts a `features` prop and renders a simple grid of feature cards.
  - Wires the component into the landing page with a small test array so the page is non-empty during development.

- Files changed
  - features.tsx — new minimal component (prop-driven, uses CSS variables like `var(--card)`, `var(--primary)`, `var(--muted-foreground)`).
  - page.tsx — passes a small `testFeatures` array to `Features` for quick verification.

- Why
  - Prevents an empty file in the repo and gives an initial, safe implementation to build upon.
  - Keeps presentation logic separate from data (component accepts props), and respects the styling system by using existing CSS variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a “Features” section to the landing page that displays feature cards in a responsive grid (adapts from single to multiple columns).
  - Each card highlights a feature title with optional description for clearer product overview.

- Style
  - The feature cards use theme-aware colors for background, text, and accents to match the app’s look and improve readability across light/dark modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->