### PR TITLE
feat: integrate theme provider for improved theming

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "../styles/globals.css";
+import { ThemeProvider } from "@/providers/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,12 +24,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
-    </html>
+    <>
+      <html lang="en" suppressHydrationWarning>
+        <head />
+        <body
+          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        >
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            {children}
+          </ThemeProvider>
+        </body>
+      </html>
+    </>
   );
 }

--- a/src/providers/theme-provider.tsx
+++ b/src/providers/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}


### PR DESCRIPTION

PR description
## Summary
Wrap the root layout with the theme provider so the entire app supports theme switching (light/dark/system). Also fix the import to use the provider from `src/providers/theme-provider`.

## What  changed
- Updated layout.tsx to wrap `<ThemeProvider>` around `{children}` and set:
  - `attribute="class"`
  - `defaultTheme="system"`
  - `enableSystem`
  - `disableTransitionOnChange`
- Added a thin re-export theme-provider.tsx that re-exports `ThemeProvider` from `src/providers/theme-provider` (keeps compatibility for any existing `@/components` imports).
- Fixed import in layout.tsx to `@/providers/theme-provider`.

## Why
- Centralizes theme handling at the root so all components can rely on Next Themes behavior (class-based theming).
- Fixes a broken/mismatched import path so the layout uses the actual provider implementation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Revamped, responsive sticky header with OpenAudit branding, desktop nav links (Features, Pricing, Contact), and a prominent “Get Started” call-to-action.
  - Mobile menu with accessible toggle, animated open/close, and one-tap link actions that close the menu.
  - App now respects system light/dark theme with seamless theme switching.

- Style
  - Updated header layout, spacing, and icons for a cleaner, more consistent look across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->