### PR TITLE
feat: add theme toggle functionality to navbar component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
       <html lang="en" suppressHydrationWarning>
         <head />
         <body
-          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+          className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}
         >
           <ThemeProvider
             attribute="class"

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -16,8 +16,10 @@ export default function Navbar() {
   }, []);
 
   const toggleTheme = () => {
-    // resolvedTheme respects system preference when defaultTheme='system'
-    setTheme(resolvedTheme === "dark" ? "light" : "dark");
+    // avoid toggling before client mount to prevent unintended theme flips
+    if (!mounted) return;
+    const next = resolvedTheme === "dark" ? "light" : "dark";
+    setTheme(next);
   };
   return (
     <nav
@@ -76,8 +78,13 @@ export default function Navbar() {
                 onClick={toggleTheme}
                 variant="ghost"
                 size="icon"
-                aria-label="Toggle theme"
+                aria-label={mounted ? `Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
+                title={mounted ? `Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
                 className="p-2"
+                type="button"
+                aria-pressed={resolvedTheme === "dark"}
+                disabled={!mounted}
+                aria-disabled={!mounted}
               >
                 {mounted ? (
                   resolvedTheme === "dark" ? (
@@ -110,11 +117,19 @@ export default function Navbar() {
 
               {/* Mobile theme toggle to the right of menu icon */}
               <Button
-                onClick={toggleTheme}
+                onClick={() => {
+                  if (!mounted) return;
+                  toggleTheme();
+                }}
                 variant="ghost"
                 size="icon"
-                aria-label="Toggle theme"
+                aria-label={mounted ? `Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
+                title={mounted ? `Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
                 className="p-2"
+                type="button"
+                aria-pressed={resolvedTheme === "dark"}
+                disabled={!mounted}
+                aria-disabled={!mounted}
               >
                 {mounted ? (
                   resolvedTheme === "dark" ? (


### PR DESCRIPTION


## PR description
Summary
Add a theme toggle to the navbar that lets users switch between light and dark modes. The toggle uses lucide-react icons and the existing `ThemeProvider` (next-themes). On desktop the control sits after the “Get Started” button; on mobile it’s placed to the right of the menu icon (visible before opening the menu). No hardcoded colors were introduced and globals.css was not modified.

Why
- Improve discoverability and accessibility of dark/light theme switching.
- Respect existing theming and design system (CSS variables + Button variants).
- Avoid UX friction by placing the mobile toggle next to the menu icon (quick access).

Implementation details
- Uses `useTheme()` from `next-themes` and `setTheme()` to toggle between "light" and "dark".
- SSR-safe: reads theme only after mount to avoid hydration mismatch.
- Uses `Sun` and `Moon` icons from `lucide-react`.
- Reuses the existing `Button` component (ghost + icon variants) — no inline color values.
- Mobile toggle moved out of the opened menu and displayed beside the menu button.

Files changed
- Navbar.tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a light/dark theme toggle to the navbar, available on both desktop and mobile.
  - Toggle reflects current theme and updates immediately after page load.

- Style
  - Updated global background and text colors to align with the active theme.
  - Adjusted navbar layout to accommodate the new theme controls while preserving spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->