### PR TITLE
feat: add theme toggle & right-align nav items on desktop

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -73,23 +73,11 @@ export default function Navbar() {
                 onClick={toggleTheme}
                 variant="ghost"
                 size="icon"
-                aria-label={
-                  mounted
-                    ? `Switch to ${
-                        resolvedTheme === "dark" ? "light" : "dark"
-                      } mode`
-                    : "Toggle theme"
-                }
-                title={
-                  mounted
-                    ? `Switch to ${
-                        resolvedTheme === "dark" ? "light" : "dark"
-                      } mode`
-                    : "Toggle theme"
-                }
+                aria-label="Toggle dark mode"
+                title="Toggle dark mode"
                 className="p-2"
                 type="button"
-                aria-pressed={resolvedTheme === "dark"}
+                aria-pressed={mounted ? resolvedTheme === "dark" : undefined}
                 disabled={!mounted}
                 aria-disabled={!mounted}
               >
@@ -124,29 +112,14 @@ export default function Navbar() {
 
               {/* Mobile theme toggle to the right of menu icon */}
               <Button
-                onClick={() => {
-                  if (!mounted) return;
-                  toggleTheme();
-                }}
+                onClick={toggleTheme}
                 variant="ghost"
                 size="icon"
-                aria-label={
-                  mounted
-                    ? `Switch to ${
-                        resolvedTheme === "dark" ? "light" : "dark"
-                      } mode`
-                    : "Toggle theme"
-                }
-                title={
-                  mounted
-                    ? `Switch to ${
-                        resolvedTheme === "dark" ? "light" : "dark"
-                      } mode`
-                    : "Toggle theme"
-                }
+                aria-label="Toggle dark mode"
+                title="Toggle dark mode"
                 className="p-2"
                 type="button"
-                aria-pressed={resolvedTheme === "dark"}
+                aria-pressed={mounted ? resolvedTheme === "dark" : undefined}
                 disabled={!mounted}
                 aria-disabled={!mounted}
               >

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -28,7 +28,7 @@ export default function Navbar() {
     >
       <div className="max-w-7xl mx-auto px-6 py-4">
         <div className="relative flex items-center justify-between">
-          {/* Left: Logo/Brand */}
+          {/* Left: Logo */}
           <div className="flex items-center">
             <Link
               href="/"
@@ -39,47 +39,54 @@ export default function Navbar() {
             </Link>
           </div>
 
-          {/* Center links: absolutely centered on md+ */}
-          <div className="hidden md:flex items-center space-x-8 absolute left-1/2 transform -translate-x-1/2">
-            <a
-              href="#features"
-              className="text-sm font-medium text-foreground hover:text-primary transition-colors"
-            >
-              Features
-            </a>
-            <a
-              href="#pricing"
-              className="text-sm font-medium text-foreground hover:text-primary transition-colors"
-            >
-              Pricing
-            </a>
-            <a
-              href="#contact"
-              className="text-sm font-medium text-foreground hover:text-primary transition-colors"
-            >
-              Contact
-            </a>
-          </div>
-
-          {/* Right: actions (Get Started + mobile toggle) */}
+          {/* Right: Desktop nav links + actions, mobile controls stay visible on small screens */}
           <div className="flex items-center space-x-3">
-            <div className="hidden md:block">
+            {/* Desktop group: moves to the right of the navbar */}
+            <div className="hidden md:flex items-center space-x-6">
+              <a
+                href="#features"
+                className="text-sm font-medium text-foreground hover:text-primary transition-colors"
+              >
+                Features
+              </a>
+              <a
+                href="#pricing"
+                className="text-sm font-medium text-foreground hover:text-primary transition-colors"
+              >
+                Pricing
+              </a>
+              <a
+                href="#contact"
+                className="text-sm font-medium text-foreground hover:text-primary transition-colors"
+              >
+                Contact
+              </a>
+
               <Button
                 asChild
                 className="bg-primary text-primary-foreground hover:bg-primary/90 font-medium"
               >
                 <Link href="/#contact">Get Started</Link>
               </Button>
-            </div>
 
-            {/* Theme toggle for md+ placed after Get Started */}
-            <div className="hidden md:block">
               <Button
                 onClick={toggleTheme}
                 variant="ghost"
                 size="icon"
-                aria-label={mounted ? `Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
-                title={mounted ? `Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
+                aria-label={
+                  mounted
+                    ? `Switch to ${
+                        resolvedTheme === "dark" ? "light" : "dark"
+                      } mode`
+                    : "Toggle theme"
+                }
+                title={
+                  mounted
+                    ? `Switch to ${
+                        resolvedTheme === "dark" ? "light" : "dark"
+                      } mode`
+                    : "Toggle theme"
+                }
                 className="p-2"
                 type="button"
                 aria-pressed={resolvedTheme === "dark"}
@@ -98,7 +105,7 @@ export default function Navbar() {
               </Button>
             </div>
 
-            {/* Mobile menu button: visible on small screens */}
+            {/* Mobile menu button + mobile theme (visible on small screens) */}
             <div className="md:hidden flex items-center gap-2">
               <button
                 type="button"
@@ -123,8 +130,20 @@ export default function Navbar() {
                 }}
                 variant="ghost"
                 size="icon"
-                aria-label={mounted ? `Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
-                title={mounted ? `Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
+                aria-label={
+                  mounted
+                    ? `Switch to ${
+                        resolvedTheme === "dark" ? "light" : "dark"
+                      } mode`
+                    : "Toggle theme"
+                }
+                title={
+                  mounted
+                    ? `Switch to ${
+                        resolvedTheme === "dark" ? "light" : "dark"
+                      } mode`
+                    : "Toggle theme"
+                }
                 className="p-2"
                 type="button"
                 aria-pressed={resolvedTheme === "dark"}


### PR DESCRIPTION

## PR description
Summary
- Move site brand (`OpenAudit`) to the far left and place navigation links, the "Get Started" button, and the theme toggle on the right for desktop view.
- Preserve mobile behavior: hamburger menu + mobile theme toggle remain on the right and the mobile menu panel remains unchanged.
- Add/ensure theme toggle is client-only (guarded by mount state) to avoid flashes and preserve accessibility attributes.

Files changed
- Navbar.tsx — reworked layout and moved desktop nav/actions to the right; kept mobile controls unchanged; included theme toggle placement and ARIA attributes.

Why
- Matches requested design: brand left, rest of the nav items and controls right with justified space between.
- Keeps mobile UX identical and preserves accessibility and SSR-safe theme toggling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - System-aware theme provider integrated with a persistent theme toggle (desktop and mobile).
  - Responsive navbar added: desktop links, CTA button, and mobile hamburger menu with panel.

- Style
  - Updated header styling and theme-adaptive colors; reduced layout shifts during theme changes.
  - Page root and body styling improved for consistent background/text across themes.

- Accessibility
  - Added ARIA attributes and keyboard-friendly controls for navigation and theme toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->