### PR TITLE
feat: add two-column structure with description and image placeholder

### DIFF
--- a/src/app/(landing)/research/research.tsx
+++ b/src/app/(landing)/research/research.tsx
@@ -25,6 +25,27 @@ export default function Research(): React.ReactElement {
             every feature is grounded in innovation and proven data
           </p>
         </div>
+
+        {/* Two-column structure: left = description + CTA placeholder, right = image placeholder */}
+        <div className="mt-12 grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
+          <div>
+            <p
+              className="text-base leading-relaxed mb-6"
+              style={{ color: "var(--foreground)" }}
+            >
+              Behind OpenAudit is a team of researchers and AI specialists who
+              have published studies, trained models, and worked on cutting-edge
+              projects. We don’t just use AI — we create it.
+            </p>
+
+            {/* CTA buttons will be added here in the next PR. Example placeholder: */}
+            <div>{/* CTA button(s) will be added here in the next PR */}</div>
+          </div>
+
+          <div className="flex items-center justify-center">
+            {/* Image placeholder — will be added in a future PR */}
+          </div>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION


## PR description
Summary
- Add a responsive two-column structure to the Research section. Keeps existing title + subtitle; left column contains the provided description and a placeholder for CTA buttons; right column contains a placeholder comment for the image to be added in a later PR.


What  changed
- Added a responsive grid (1 column on small screens, 2 columns on md+) under the existing title/subtitle.
- Inserted the supplied description text in the left column:
  - "Behind OpenAudit is a team of researchers and AI specialists who have published studies, trained models, and worked on cutting-edge projects. We don’t just use AI — we create it."
- Left a visible placeholder comment where CTA button(s) should go (buttons will be added in a follow-up PR).
- Left a visible placeholder comment where the image will go (image will be added in a follow-up PR).
- No changes to styles or global variables.

Why
- Separate structural work (layout + content placement) from interactive elements (CTAs) and assets (image) so follow-up PRs can add them without layout churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a responsive two-column section to the Research page, positioned after the existing description.
  - Left column introduces a new paragraph about the OpenAudit team with consistent text styling.
  - Right column provides a placeholder area for a future image.
- Style
  - Implemented a clean, responsive grid layout while preserving existing headings and color scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->