### PR TITLE
feat: add RevolutionaryFeatures component with initial layout and content

### DIFF
--- a/src/app/(landing)/RevolutionaryFeatures/revolutionaryFeatures.tsx
+++ b/src/app/(landing)/RevolutionaryFeatures/revolutionaryFeatures.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export default function RevolutionaryFeatures(): React.ReactElement {
+  return (
+    <section className="max-w-4xl mx-auto py-12 px-6">
+      <div className="px-6">
+        <div className="text-center">
+          <h2
+            className="mx-auto font-extrabold leading-tight"
+            style={{
+              color: "var(--foreground)",
+              fontSize: "clamp(28px, 6.4vw, 48px)",
+              maxWidth: "900px",
+            }}
+          >
+            Revolutionary Features
+          </h2>
+
+          <p
+            className="mt-4 mx-auto max-w-2xl text-base leading-relaxed"
+            style={{ color: "var(--muted-foreground)" }}
+          >
+            Experience the future of smart contract security with features
+            designed for the modern blockchain developer.
+          </p>
+        </div>
+
+        {/* Placeholder area for feature cards */}
+        <div className="mt-12">
+          {/* revolutionary Features Cards will be here */}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION

### PR description
- Summary
  - ✨ Adds a new `RevolutionaryFeatures` component that provides the section structure used on the landing page: heading, subheading, and a placeholder area for the feature cards.
- What I changed
  - Created/updated revolutionaryFeatures.tsx with:
    - Title and subtitle markup matching the `Research` component pattern
    - A placeholder container and inline comment: "revolutionary Features Cards will be here"
    - No hardcoded colors — uses CSS variables defined in `global.css`
- Why
  - Provides the structural layout so designers/developers can implement feature cards independently while preserving global theming and responsive typography.
