### PR TITLE
feat: implement PricingSection with responsive placeholder cards

### DIFF
--- a/src/app/(landing)/pricing/pricing.tsx
+++ b/src/app/(landing)/pricing/pricing.tsx
@@ -1,33 +1,35 @@
-import { Card } from "@/components/ui/card";
-
 export default function PricingSection() {
   return (
-    <section className="py-16 px-4 bg-muted/30">
-      <div className="max-w-6xl mx-auto text-center">
-        <h2 className="text-3xl font-bold text-foreground mb-4">
-          Pricing Plans
-        </h2>
-        <p className="text-muted-foreground mb-8 max-w-2xl mx-auto">
-          Choose the perfect plan for your needs
-        </p>
-
-        <Card className="max-w-md mx-auto p-8 border-dashed border-2 border-border bg-card">
+    <section
+      aria-labelledby="pricing-heading"
+      className="relative overflow-hidden py-16 sm:py-20"
+    >
+      <div className="max-w-6xl mx-auto py-12 px-6">
+        <div className="px-6">
           <div className="text-center">
-            <div className="w-16 h-16 mx-auto mb-4 bg-muted rounded-full flex items-center justify-center">
-              <span className="text-2xl">🚧</span>
-            </div>
-            <h3 className="text-xl font-semibold text-card-foreground mb-2">
-              Pricing Section
-            </h3>
-            <p className="text-muted-foreground text-sm mb-4">
-              This is a placeholder component. Pricing plans and features will
-              be added here.
+            <h2
+              className="mx-auto font-extrabold leading-tight"
+              style={{
+                color: "var(--foreground)",
+                fontSize: "clamp(28px, 6.4vw, 48px)",
+                maxWidth: "900px",
+              }}
+            >
+              Choose The Best Pack for You
+            </h2>
+
+            <p
+              className="mt-4 mx-auto max-w-2xl text-base leading-relaxed"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              Use credits to scan your documents. 1 credit ≈ 1,000 characters.
             </p>
-            <div className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-accent text-accent-foreground">
-              🔨 Under Construction
-            </div>
           </div>
-        </Card>
+
+          <div className="mt-12">
+            {/* here pricing cards will be implemented */}
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/src/app/(landing)/pricing/pricing.tsx
+++ b/src/app/(landing)/pricing/pricing.tsx
@@ -8,6 +8,7 @@ export default function PricingSection() {
         <div className="px-6">
           <div className="text-center">
             <h2
+              id="pricing-heading"
               className="mx-auto font-extrabold leading-tight"
               style={{
                 color: "var(--foreground)",

--- a/src/app/(landing)/pricing/pricing.tsx
+++ b/src/app/(landing)/pricing/pricing.tsx
@@ -1,4 +1,11 @@
 export default function PricingSection() {
+  const plans = [
+    { id: "p1", name: "Quickie", price: "$0.99", credits: "1 Credit" },
+    { id: "p2", name: "Edge", price: "$5.49", credits: "5 Credit" },
+    { id: "p3", name: "Goon", price: "$9.49", credits: "12 Credit" },
+    { id: "p4", name: "Segs", price: "$18.49", credits: "25 Credit" },
+  ];
+
   return (
     <section
       aria-labelledby="pricing-heading"
@@ -28,7 +35,65 @@ export default function PricingSection() {
           </div>
 
           <div className="mt-12">
-            {/* here pricing cards will be implemented */}
+            {/* Pricing cards grid: 1col on mobile, 2 on tablet, 4 on desktop */}
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+              {plans.map((plan) => (
+                <article
+                  key={plan.id}
+                  className="flex flex-col rounded-2xl border p-6 shadow-sm"
+                  style={{
+                    backgroundColor: "var(--card)",
+                    borderColor: "var(--border)",
+                  }}
+                  aria-labelledby={`plan-${plan.id}`}
+                >
+                  <h3
+                    id={`plan-${plan.id}`}
+                    className="text-lg font-semibold mb-2"
+                    style={{ color: "var(--foreground)" }}
+                  >
+                    {plan.name}
+                  </h3>
+
+                  <div className="mb-4">
+                    <div
+                      className="text-3xl font-extrabold"
+                      style={{ color: "var(--foreground)" }}
+                    >
+                      {plan.price}
+                    </div>
+                    <div
+                      className="text-sm mt-1"
+                      style={{ color: "var(--muted-foreground)" }}
+                    >
+                      {plan.credits}
+                    </div>
+                  </div>
+
+                  <ul
+                    className="mb-6 space-y-2 text-sm"
+                    style={{ color: "var(--muted-foreground)" }}
+                  >
+                    <li>• Placeholder benefit 1</li>
+                    <li>• Placeholder benefit 2</li>
+                    <li>• Placeholder benefit 3</li>
+                  </ul>
+
+                  <div className="mt-auto w-full">
+                    <button
+                      type="button"
+                      className="w-full rounded-md px-4 py-2 font-semibold"
+                      style={{
+                        background: "var(--primary)",
+                        color: "var(--primary-foreground)",
+                      }}
+                    >
+                      Start {plan.name}
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## PR description
Summary
- Implement a PricingSection with placeholder pricing cards and a responsive layout.
- Adds a grid of placeholder plan cards (desktop: 4 columns, tablet: 2, mobile: 1).
- Uses existing CSS variables for colors (no hardcoded color values).
- No changes to globals.css.

What  changed
- Modified: pricing.tsx
  - Added a small `plans` array and rendered placeholder cards.
  - Cards use Tailwind utility classes + CSS variables (e.g. `var(--card)`, `var(--border)`, `var(--foreground)`, `var(--muted-foreground)`, `var(--primary)`, `var(--primary-foreground)`).
  - Layout: `grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4` with spacing and simple card structure.
  - Buttons and card backgrounds use CSS variables—no global CSS edits.


