### PR TITLE
feat: pricing card typed memo intl

### DIFF
--- a/src/app/(landing)/pricing/pricing.tsx
+++ b/src/app/(landing)/pricing/pricing.tsx
@@ -1,4 +1,59 @@
-import PricingCard from "@/components/landing/PricingTableCard";
+import PricingCard, { type Plan } from "@/components/landing/PricingTableCard";
+
+const plans: Plan[] = [
+  {
+    id: "p-lite",
+    name: "Lite",
+    subtitle: "Perfect for getting started",
+    price: 0.99,
+    credits: 1,
+    badge: null,
+    features: [
+      "Instant Credit Delivery",
+      "No Expiration Date",
+      "Basic support included",
+    ],
+  },
+  {
+    id: "p-pro",
+    name: "Pro",
+    subtitle: "Great for regular users",
+    price: 5.49,
+    credits: 5,
+    badge: "Most Popular",
+    features: [
+      "Instant Credit Delivery",
+      "No Expiration Date",
+      "Priority support",
+    ],
+  },
+  {
+    id: "p-plus",
+    name: "Plus",
+    subtitle: "For power users",
+    price: 9.49,
+    credits: 12,
+    badge: null,
+    features: [
+      "Instant Credit Delivery",
+      "No Expiration Date",
+      "Priority support",
+    ],
+  },
+  {
+    id: "p-premium",
+    name: "Premium",
+    subtitle: "Best for teams and power users",
+    price: 18.49,
+    credits: 25,
+    badge: "Best Value",
+    features: [
+      "Instant Credit Delivery",
+      "No Expiration Date",
+      "Dedicated support",
+    ],
+  },
+];
 
 export default function PricingSection() {
   const plans = [
@@ -64,7 +119,39 @@ export default function PricingSection() {
     >
       <div className="max-w-6xl mx-auto py-12 px-6">
         <div className="px-6">
+    <section
+      id="pricing"
+      aria-labelledby="pricing-heading"
+      className="relative overflow-hidden py-16 sm:py-20"
+    >
+      <div className="max-w-6xl mx-auto py-12 px-6">
+        <div className="px-6">
           <div className="text-center">
+            <h2
+              id="pricing-heading"
+              className="mx-auto font-extrabold leading-tight"
+              style={{
+                color: "var(--foreground)",
+                fontSize: "clamp(28px, 6.4vw, 48px)",
+                maxWidth: "900px",
+              }}
+            >
+              Choose The Best Pack for You
+            </h2>
+
+            <p
+              className="mt-4 mx-auto max-w-2xl text-base leading-relaxed"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              Use credits to scan your documents. 1 credit ≈ 1,000 characters.
+            </p>
+          </div>
+
+          <div className="mt-12">
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+              {plans.map((p) => (
+                <PricingCard key={p.id} {...p} />
+              ))}
             <h2
               id="pricing-heading"
               className="mx-auto font-extrabold leading-tight"
@@ -92,6 +179,7 @@ export default function PricingSection() {
               ))}
             </div>
           </div>
+        </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION

###  PR description:
  Summary
  - ✨ Preserve UI while simplifying implementation.
  - 🔢 Use `Plan` with numeric `price` and format using Intl (USD).
  - 🧠 Memoize per-credit and badge flags; wrap card with `React.memo`.
  - 📦 Hoist `plans` to avoid recreating data every render.

  Files changed
  - PricingTableCard.tsx — typed `Plan`, currency formatter, memoized logic, same design.
  - pricing.tsx — typed plans, numeric prices, hoisted constant.

  Why
  - Fewer renders, clearer types, better internationalization and maintainability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a full pricing grid with four plans (Lite, Pro, Plus, Premium), dynamic plan cards with badges, per-credit info, responsive layout, hover glow effects, and improved header/description with accessibility labeling.
- Refactor
  - Replaced placeholder pricing section with a data-driven implementation using a reusable pricing card; removed obsolete pricing component. Marked UI card as a client component without changing its API.
- Style
  - Normalized color tokens, reformatted shadow variables, and added a new --on-chart-4 variable to improve contrast; minor formatting cleanups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->