### PR TITLE
feat: refactor PricingSection to streamline plan data and improve layout

### DIFF
--- a/src/app/(landing)/pricing/pricing.tsx
+++ b/src/app/(landing)/pricing/pricing.tsx
@@ -56,69 +56,7 @@ const plans: Plan[] = [
 ];
 
 export default function PricingSection() {
-  const plans = [
-    {
-      id: "p-lite",
-      name: "Lite",
-      subtitle: "Perfect for getting started",
-      price: "$0.99",
-      credits: 1,
-      badge: null,
-      features: [
-        "Instant Credit Delivery",
-        "No Expiration Date",
-        "Basic support included",
-      ],
-    },
-    {
-      id: "p-pro",
-      name: "Pro",
-      subtitle: "Great for regular users",
-      price: "$5.49",
-      credits: 5,
-      badge: "Most Popular",
-      features: [
-        "Instant Credit Delivery",
-        "No Expiration Date",
-        "Priority support",
-      ],
-    },
-    {
-      id: "p-plus",
-      name: "Plus",
-      subtitle: "For power users",
-      price: "$9.49",
-      credits: 12,
-      badge: null,
-      features: [
-        "Instant Credit Delivery",
-        "No Expiration Date",
-        "Priority support",
-      ],
-    },
-    {
-      id: "p-premium",
-      name: "Premium",
-      subtitle: "Best for teams and power users",
-      price: "$18.49",
-      credits: 25,
-      badge: "Best Value",
-      features: [
-        "Instant Credit Delivery",
-        "No Expiration Date",
-        "Dedicated support",
-      ],
-    },
-  ];
-
   return (
-    <section
-      id="pricing"
-      aria-labelledby="pricing-heading"
-      className="relative overflow-hidden py-16 sm:py-20"
-    >
-      <div className="max-w-6xl mx-auto py-12 px-6">
-        <div className="px-6">
     <section
       id="pricing"
       aria-labelledby="pricing-heading"
@@ -152,34 +90,8 @@ export default function PricingSection() {
               {plans.map((p) => (
                 <PricingCard key={p.id} {...p} />
               ))}
-            <h2
-              id="pricing-heading"
-              className="mx-auto font-extrabold leading-tight"
-              style={{
-                color: "var(--foreground)",
-                fontSize: "clamp(28px, 6.4vw, 48px)",
-                maxWidth: "900px",
-              }}
-            >
-              Choose The Best Pack for You
-            </h2>
-
-            <p
-              className="mt-4 mx-auto max-w-2xl text-base leading-relaxed"
-              style={{ color: "var(--muted-foreground)" }}
-            >
-              Use credits to scan your documents. 1 credit ≈ 1,000 characters.
-            </p>
-          </div>
-
-          <div className="mt-12">
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
-              {plans.map((p) => (
-                <PricingCard key={p.id} {...p} />
-              ))}
             </div>
           </div>
-        </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### PR description
Summary
- Remove duplicated and misnested JSX in the Pricing section and use the top-level typed `plans` array. This consolidates the markup into a single, accessible pricing section and prevents duplicated IDs and duplicate rendering.

What I changed
- Edited pricing.tsx:
  - Removed a duplicate inner `plans` array and duplicated nested `<section>` markup.
  - Kept a single section and rendering of `{plans.map(...)}` using the declared `Plan[]`.
  - Eliminated duplicated `id="pricing"` and `id="pricing-heading"` instances.

Why
- The file contained duplicated, misnested JSX which caused duplicate IDs and redundant content rendering.
- Clean structure improves accessibility, prevents rendering bugs, and makes the code easier to maintain.

