### PR TITLE
feat: add OpenAuditAction component with introductory content and layout

### DIFF
--- a/src/app/(landing)/OpenAuditAction/OpenAuditAction.tsx
+++ b/src/app/(landing)/OpenAuditAction/OpenAuditAction.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function OpenAuditAction(): React.ReactElement {
   return (
-    <section className="max-w-6xl mx-auto py-12 px-6">
+  <section id="open-audit-action" className="max-w-6xl mx-auto py-12 px-6">
       <div className="px-6">
         <div className="text-center">
           <h2

--- a/src/app/(landing)/OpenAuditAction/OpenAuditAction.tsx
+++ b/src/app/(landing)/OpenAuditAction/OpenAuditAction.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+export default function OpenAuditAction(): React.ReactElement {
+  return (
+    <section className="max-w-6xl mx-auto py-12 px-6">
+      <div className="px-6">
+        <div className="text-center">
+          <h2
+            className="mx-auto font-extrabold leading-tight"
+            style={{
+              color: "var(--foreground)",
+              fontSize: "clamp(28px, 6.4vw, 48px)",
+              maxWidth: "900px",
+            }}
+          >
+            See OpenAudit In Action
+          </h2>
+
+          <p
+            className="mt-4 mx-auto max-w-2xl text-base leading-relaxed"
+            style={{ color: "var(--muted-foreground)" }}
+          >
+            Watch how our AI engine instantly identifies vulnerabilities in
+            smart contracts.
+          </p>
+        </div>
+
+        {/* Placeholder area for interactive demo + report */}
+        {/* that will be implemented here */}
+        <div className="mt-12">
+          {/* Demo UI (code editor + report) will be added here in a follow-up PR. */}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -66,7 +66,7 @@ export default function Navbar() {
                 asChild
                 className="bg-primary text-primary-foreground hover:bg-primary/90 font-medium"
               >
-                <Link href="/#contact">Get Started</Link>
+                <Link href="/#open-audit-action">Get Started</Link>
               </Button>
 
               <Button
@@ -173,7 +173,7 @@ export default function Navbar() {
               asChild
               className="w-full bg-primary text-primary-foreground hover:bg-primary/90 font-medium"
             >
-              <Link href="/#contact" onClick={() => setOpen(false)}>
+              <Link href="/#open-audit-action" onClick={() => setOpen(false)}>
                 Get Started
               </Link>
             </Button>


### PR DESCRIPTION


##  PR description
Summary
- Add a heading and subtitle to the OpenAuditAction section to match the pattern used in `RevolutionaryFeatures`. Leaves a placeholder where the interactive demo (code editor + security report) will be implemented in a follow-up PR.

Files changed
- OpenAuditAction.tsx

What  changed
- Implemented the section header:
  - Title: "See OpenAudit In Action"
  - Subtitle: "Watch how our AI engine instantly identifies vulnerabilities in smart contracts."
- Used CSS variables for colors (`var(--foreground)` and `var(--muted-foreground)`) — no hardcoded color values.
- Inserted a placeholder comment and an empty container where the demo and report UI will be added: "that will be implemented here".
- No edits to `global.css` or other global styles.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “See OpenAudit In Action” section to the landing page with a prominent headline, supporting copy about instant smart contract vulnerability detection, and a visible placeholder for an upcoming interactive demo and report.
  * Uses a responsive, centered layout to improve readability across devices; static content for now.

* **Bug Fixes**
  * Updated Get Started links to navigate to the new OpenAudit section anchor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->