### PR TITLE
feat: enhance Hero and HeroCarousel components with improved layout and hover pause functionality

### DIFF
--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -14,13 +14,15 @@ export default function Hero() {
         }}
       />
 
-  <div className="mx-auto w-full max-w-7xl px-4 md:py-16 lg:py-20">
+  <div className="mx-auto w-full max-w-7xl px-4 py-6 md:py-10 lg:py-12">
         <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-balance text-3xl font-semibold tracking-tight md:text-5xl lg:text-6xl">
+          <h1 className="text-balance text-3xl font-semibold tracking-tight leading-tight md:text-5xl lg:text-6xl">
             Secure Your Smart Contracts with OpenAudit
           </h1>
         </div>
-          <HeroCarousel />
+          <div className="mt-4 md:mt-6">
+            <HeroCarousel />
+          </div>
       </div>
     </section>
   );

--- a/src/components/landing/hero/HeroCarousel.tsx
+++ b/src/components/landing/hero/HeroCarousel.tsx
@@ -14,18 +14,27 @@ export default function HeroCarousel() {
 
 	// Track the center slide index and auto-rotate
 	const [current, setCurrent] = useState(0);
+  // Pause rotation on hover
+  const [paused, setPaused] = useState(false);
 
 	useEffect(() => {
+    if (paused) return;
 		const id = setInterval(() => {
 			setCurrent((c) => (c + 1) % slides.length);
 		}, 4000);
 		return () => clearInterval(id);
-	}, [slides.length]);
+	}, [slides.length, paused]);
 
 	return (
-		<div className="relative mx-auto max-w-[300px] overflow-visible">
-			{/* Sizer to reserve layout space (matches center slide size) */}
-			<div className={`${baseWidths} aspect-[16/9] invisible`} />
+		<div
+        className="relative mx-auto max-w-[300px] overflow-visible"
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+      >
+			{/* Sizer to reserve layout space (matches scaled center slide height) */}
+			<div
+				className={`${baseWidths} invisible h-[150px] sm:h-[250px] md:h-[350px] lg:h-[450px] xl:h-[530px] 2xl:h-[600px]`}
+			/>
 
 			{/* Animated slides layered absolutely; positions are derived from `current` */}
 			{slides.map((s, idx) => {


### PR DESCRIPTION
## Hero Section & Carousel Improvements

### Changes
- **Hero Section Spacing:** Eased vertical padding and increased gap between heading and carousel for better layout balance.
- **Carousel Hover Pause:** Added mouse enter/leave events to the hero carousel. When the user hovers over the carousel, auto-rotation pauses; it resumes when the mouse leaves.
- No changes to carousel scales or slide visuals.

### Why
- Prevents the hero section from being cut off or cramped by adjacent sections.
- Improves user experience by allowing users to pause carousel animation for easier viewing.

---

**Files changed:**
- `src/components/landing/Hero.tsx`
- `src/components/landing/hero/HeroCarousel.tsx`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Carousel now pauses on hover and resumes on mouse leave, improving user control over slide rotation.

* **Style**
  * Reduced vertical padding in the hero section for a more compact layout on medium and large screens.
  * Tightened main heading line height for improved readability.
  * Added vertical spacing above the carousel to separate it from the heading.
  * Adjusted carousel sizing behavior for more responsive height scaling across breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->