### PR TITLE
feat: add navigation buttons and click-to-center to HeroCarousel

### DIFF
--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -14,13 +14,15 @@ export default function Hero() {
         }}
       />
 
-  <div className="mx-auto w-full max-w-7xl px-4 md:py-16 lg:py-20">
+  <div className="mx-auto w-full max-w-7xl px-4 py-6 md:py-10 lg:py-12">
         <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-balance text-3xl font-semibold tracking-tight md:text-5xl lg:text-6xl">
+          <h1 className="text-balance text-3xl font-semibold tracking-tight leading-tight md:text-5xl lg:text-6xl">
             Secure Your Smart Contracts with OpenAudit
           </h1>
         </div>
-          <HeroCarousel />
+          <div className="mt-4 md:mt-6">
+            <HeroCarousel />
+          </div>
       </div>
     </section>
   );

--- a/src/components/landing/hero/HeroCarousel.tsx
+++ b/src/components/landing/hero/HeroCarousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
+import { Button } from "@/components/ui/button";
 
 export default function HeroCarousel() {
 	const slides = [
@@ -55,13 +56,13 @@ export default function HeroCarousel() {
 					].join(" ");
 				} else if (isLeft) {
 					posClasses = [
-						"pointer-events-none opacity-60 z-0 scale-30 blur-[1px]",
+						"opacity-60 z-0 scale-30 blur-[1px] cursor-pointer",
 						"hidden sm:block",
 						"left-1/2 top-0 translate-y-4 translate-x-[-75%]",
 					].join(" ");
 				} else if (isRight) {
 					posClasses = [
-						"pointer-events-none opacity-60 z-0 scale-30 blur-[1px]",
+						"opacity-60 z-0 scale-30 blur-[1px] cursor-pointer",
 						"hidden sm:block",
 						"left-1/2 top-0 translate-y-4 translate-x-[-25%]",
 					].join(" ");
@@ -83,9 +84,32 @@ export default function HeroCarousel() {
 						alt={s.alt}
 						priority={isCenter}
 						aria-hidden={!isCenter}
+						onClick={() => {
+							if (!isCenter) setCurrent(idx);
+						}}
 					/>
 				);
 			})}
+
+			{/* Controls */}
+			<div className="mt-3 flex items-center justify-center gap-3">
+				<Button
+					variant="outline"
+					size="sm"
+					aria-label="Previous slide"
+					onClick={() => setCurrent((c) => (c + slides.length - 1) % slides.length)}
+				>
+					Prev
+				</Button>
+				<Button
+					variant="outline"
+					size="sm"
+					aria-label="Next slide"
+					onClick={() => setCurrent((c) => (c + 1) % slides.length)}
+				>
+					Next
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/src/components/landing/hero/HeroCarousel.tsx
+++ b/src/components/landing/hero/HeroCarousel.tsx
@@ -14,18 +14,27 @@ export default function HeroCarousel() {
 
 	// Track the center slide index and auto-rotate
 	const [current, setCurrent] = useState(0);
+  // Pause rotation on hover
+  const [paused, setPaused] = useState(false);
 
 	useEffect(() => {
+    if (paused) return;
 		const id = setInterval(() => {
 			setCurrent((c) => (c + 1) % slides.length);
 		}, 4000);
 		return () => clearInterval(id);
-	}, [slides.length]);
+	}, [slides.length, paused]);
 
 	return (
-		<div className="relative mx-auto max-w-[300px] overflow-visible">
-			{/* Sizer to reserve layout space (matches center slide size) */}
-			<div className={`${baseWidths} aspect-[16/9] invisible`} />
+		<div
+        className="relative mx-auto max-w-[300px] overflow-visible"
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+      >
+			{/* Sizer to reserve layout space (matches scaled center slide height) */}
+			<div
+				className={`${baseWidths} invisible h-[150px] sm:h-[250px] md:h-[350px] lg:h-[450px] xl:h-[530px] 2xl:h-[600px]`}
+			/>
 
 			{/* Animated slides layered absolutely; positions are derived from `current` */}
 			{slides.map((s, idx) => {


### PR DESCRIPTION



## PR Description
This PR enhances the `HeroCarousel` component with improved slide control and interactivity:

- Adds "Prev" and "Next" navigation buttons below the carousel for manual slide navigation.
- Makes side slides clickable; clicking a side slide brings it to the center.
- Improves user experience by allowing both button and direct slide selection.
- Retains existing mouse hover-to-pause functionality.

These changes make the carousel more interactive and accessible for users.

---
Files changed:
- `src/components/landing/hero/HeroCarousel.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Carousel now pauses on hover.
  * Click any side slide to bring it to the center.
  * Added Prev/Next controls with accessible labels for manual navigation.

* **Style**
  * Adjusted hero section padding across breakpoints for improved spacing on small and large screens.
  * Tightened heading line-height for better readability.
  * Refined carousel spacing and responsive sizing to reduce layout shift and improve visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->