### PR TITLE
feat: remove manual slide controls from HeroCarousel component

### DIFF
--- a/src/components/landing/hero/HeroCarousel.tsx
+++ b/src/components/landing/hero/HeroCarousel.tsx
@@ -90,26 +90,7 @@ export default function HeroCarousel() {
 					/>
 				);
 			})}
-
-			{/* Controls */}
-			<div className="mt-3 flex items-center justify-center gap-3">
-				<Button
-					variant="outline"
-					size="sm"
-					aria-label="Previous slide"
-					onClick={() => setCurrent((c) => (c + slides.length - 1) % slides.length)}
-				>
-					Prev
-				</Button>
-				<Button
-					variant="outline"
-					size="sm"
-					aria-label="Next slide"
-					onClick={() => setCurrent((c) => (c + 1) % slides.length)}
-				>
-					Next
-				</Button>
-			</div>
+			
 		</div>
 	);
 }


### PR DESCRIPTION

## Description
This PR removes the manual "Prev" and "Next" slide controls from the `HeroCarousel` component. The carousel now operates without user-triggered navigation buttons, resulting in a cleaner and more streamlined UI.

### Changes
- Deleted the button controls for previous and next slide navigation.
- Updated layout to remove the controls section and associated handlers.

## Impact
- Simplifies the carousel interface for users.
- Reduces visual clutter and focuses attention on the carousel content.
- Navigation is now handled automatically or by other means (e.g., swipe, auto-play).

---

**Reviewer Notes:**  
Please verify carousel usability and ensure that slide transitions still work as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Hero carousel no longer shows Prev/Next controls; manual navigation via those buttons is no longer available.
  - Auto-rotation continues at 4-second intervals and pauses on hover; slide click actions are unchanged.
  - Streamlines the carousel interface without altering rotation timing or hover behavior.
  - No other visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->